### PR TITLE
catch literal_eval errors

### DIFF
--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -49,7 +49,8 @@ class Parser(NativeEnvironment):
 
         Parses and returns valid literals.
 
-        Raises exceptions for expressions.
+        Raises:
+            ValueError: When it encounters expressions.
 
         Examples:
             >>> parser = Parser()
@@ -88,15 +89,15 @@ class Parser(NativeEnvironment):
             # invalid examples
             >>> parser.literal_eval('1 + 1')
             Traceback (most recent call last):
-            Exception: Invalid literal: 1 + 1
+            ValueError: Invalid literal: 1 + 1
             <class 'jinja2.nodes.Add'>
             >>> parser.literal_eval('range(5)')
             Traceback (most recent call last):
-            Exception: Invalid literal: range(5)
+            ValueError: Invalid literal: range(5)
             <class 'jinja2.nodes.Call'>
             >>> parser.literal_eval('1 if True else 0')
             Traceback (most recent call last):
-            Exception: Invalid literal: 1 if True else 0
+            ValueError: Invalid literal: 1 if True else 0
             <class 'jinja2.nodes.CondExpr'>
 
             # quirks
@@ -118,7 +119,7 @@ class Parser(NativeEnvironment):
         while stack:
             node = stack.pop()
             if not isinstance(node, self._LITERAL_NODES):
-                raise Exception(
+                raise ValueError(
                     f'Invalid literal: {value}'
                     f'\n{type(node)}'
                 )

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -1,0 +1,49 @@
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests the plugin with Rose suite configurations via the Python API."""
+
+import pytest
+
+from metomi.rose.config import (
+    ConfigNode,
+)
+from metomi.rose.config_processor import ConfigProcessError
+
+from cylc.rose.rose import (
+    get_rose_vars_from_config_node,
+)
+
+
+def test_blank():
+    """It should provide only standard vars for a blank config."""
+    ret = {}
+    node = ConfigNode()
+    get_rose_vars_from_config_node(ret, node, {})
+    assert set(ret.keys()) == {'env'}
+    assert set(ret['env'].keys()) == {
+        'ROSE_ORIG_HOST',
+        'ROSE_SITE',
+        'ROSE_VERSION',
+    }
+
+
+def test_invalid_templatevar():
+    """It should wrap eval errors as something more informative."""
+    ret = {}
+    node = ConfigNode()
+    node.set(['jinja2:suite.rc', 'X'], 'Y')
+    with pytest.raises(ConfigProcessError):
+        get_rose_vars_from_config_node(ret, node, {})


### PR DESCRIPTION
sibling: https://github.com/metomi/rose/pull/2430

Catch literal_eval errors and wrap them with `ConfigProcessError` to provide a more helpful error message.
Once #9 is done only the last line will appear in the Cylc command line output.

*Example:*

```ini
[jinja2:suite.rc]
X=Y
```

*Before:*

```
Traceback (most recent call last):
...
ValueError: malformed node or string: <_ast.Name object at 0x7f9c43c95ed0>
```

*After:*

```
Traceback (most recent call last):
...
metomi.rose.config_processor.ConfigProcessError: jinja2:suite.rc=Y=X: Invalid template variable: X
Must be a valid Python or Jinja2 literal (note strings "must be quoted").
```