### PR TITLE
Ignore ROSE_VERSION and CYLC_VERSION

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -91,6 +91,24 @@ def get_rose_vars_from_config_node(config, config_node, environ):
         if rose_orig_host:
             config_node[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
 
+        # Remove CYLC_VERSION to prevent conflict with Cylc 8.
+        if 'CYLC_VERSION' in config_node[section]:
+            LOG.warning(
+                f'CYLC_VERSION={config_node[section]["CYLC_VERSION"].value} '
+                'in rose-suite.conf will be ignored '
+                'to prevent conflict with Cylc 8 settings.'
+            )
+            del config_node[section]['CYLC_VERSION']
+        # If ROSE_VERSION is not the version we are using warn and replace.
+        if 'ROSE_VERSION' in config_node[section]:
+            LOG.warning(
+                'ROSE_VERSION='
+                f'{config_node[section]["ROSE_VERSION"].value} '
+                'in rose-suite.conf will be ignored. You are '
+                f'using version {ROSE_VERSION}.'
+            )
+        config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
+
         # Use env_var_process to process variables which may need expanding.
         for key, node in config_node.value[section].value.items():
             try:

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -87,7 +87,6 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     for section in ['env', templating]:
         # Add standard ROSE_VARIABLES
         config_node[section].set(['ROSE_SITE'], rose_site)
-        config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
         if rose_orig_host:
             config_node[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
 

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -246,7 +246,7 @@ def test_get_rose_vars_ROSE_VARS(tmp_path):
     """Test that rose variables are available in the environment section.."""
     (tmp_path / "rose-suite.conf").touch()
     rose_vars = get_rose_vars(tmp_path)
-    assert sorted(list(rose_vars['env'].keys())) == [
+    assert sorted(rose_vars['env'].keys()) == [
         'ROSE_ORIG_HOST',
         'ROSE_SITE',
         'ROSE_VERSION',
@@ -259,9 +259,9 @@ def test_get_rose_vars_jinja2_ROSE_VARS(tmp_path):
         "[jinja2:suite.rc]"
     )
     rose_vars = get_rose_vars(tmp_path)
-    assert sorted(list(rose_vars['template_variables'][
+    assert sorted(rose_vars['template_variables'][
         'ROSE_SUITE_VARIABLES'
-    ].keys())) == [
+    ].keys()) == [
         'ROSE_ORIG_HOST',
         'ROSE_SITE',
         'ROSE_SUITE_VARIABLES',


### PR DESCRIPTION
Closes #11 
Doesn't create any further tech debt, and provides a template for #12 

### Summary
Prevent user setting values for `CYLC_VERSION` and `ROSE_VERSION` from rose config.
- `ROSE_VERSION` will be retrieved from `metomi.rose.__version__`. If the user had set it otherwise a warning will be printed.
- `CYLC_VERSION` will be deleted with a warning.

- [x] Addressed issue
- [x] Created a new test to test this fix.