### PR TITLE
Enable `rose-suite.conf[template variables]`

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -65,9 +65,9 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             f"You defined:\n\t{'; '.join(defined_sections)}"
         )
     elif len(defined_sections) == 1:
-        templating, = list(defined_sections)
-    if templating is not None:
-        config['templating_detected'] = templating
+        templating, = defined_sections
+        if templating != 'template variables':
+            config['templating_detected'] = templating.replace(':suite.rc', '')
 
     # Get Values for standard ROSE variables.
     rose_orig_host = get_host()

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -68,6 +68,8 @@ def get_rose_vars_from_config_node(config, config_node, environ):
         templating, = defined_sections
         if templating != 'template variables':
             config['templating_detected'] = templating.replace(':suite.rc', '')
+        else:
+            config['templating_detected'] = templating
 
     # Get Values for standard ROSE variables.
     rose_orig_host = get_host()
@@ -108,12 +110,17 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             item[0][1]: item[1].value for item in
             config_node.value['env'].walk()
         }
-
     if templating in config_node.value:
         config['template_variables'] = {
             item[0][1]: item[1].value for item in
             config_node.value[templating].walk()
         }
+    elif 'template variables' in config_node.value:
+        config['template_variables'] = {
+            item[0][1]: item[1].value for item in
+            config_node.value['template variables'].walk()
+        }
+
     # Add the entire config to ROSE_SUITE_VARIABLES to allow for programatic
     # access.
     if templating is not None:

--- a/tests/functional/09_template_vars_vanilla/flow.cylc
+++ b/tests/functional/09_template_vars_vanilla/flow.cylc
@@ -1,0 +1,64 @@
+#!jinja2
+# Test with rose `XYZ=xyz suite-run --new -l` (which invokes cylc validate --strict)
+# Rose env vars are logged to the console
+
+# 1. The Jinja2 shebang should be added automatically
+{{ assert(True, "failed 1.1") }}
+
+##
+{% from "subprocess" import Popen %}
+{% from "subprocess" import PIPE %}
+{% from "cylc.flow" import LOG %} # cylc8
+
+# 2. ROSE_SUITE_VARIABLES should contain a mapping of all vars
+{{ assert(ROSE_SUITE_VARIABLES is defined, "failed 2.1") }}
+{{ assert(ROSE_SUITE_VARIABLES["INT"] == 42, "failed 2.2") }}
+{% do LOG.info(ROSE_SUITE_VARIABLES) %}
+
+# 3. Env vars
+# 3.1 - Local env vars should be templated into rose-suite.conf[env]
+{{ assert(LOCAL_ENV == "xyz", "failed 3.1") }}
+# 3.2 - rose-suite.conf[env] vars should be templated into rose-suite.conf[jinja2:suite.rc]
+{{ assert(BAR == "ab", "failed 3.2") }}
+# 3.3 - Escaped env vars should not be templated
+{{ assert(ESCAPED_ENV == "$HOME", "failed 3.3") }}
+
+# 4. Literals should be evaluated
+{{ assert(INT == 42, "failed 4.1") }}
+{{ assert(BOOL == True, "failed 4.2") }}
+{{ assert(LIST == ["a", 1, True], "failed 4.3") }}
+
+# 5. ROSE_VERSION should be provided
+{{ assert(ROSE_VERSION is defined, "failed 5.1") }}
+{% set cli_rose_version = Popen(["rose", "version"], stdout=PIPE).communicate()[0] %}
+{% set cli_rose_version = cli_rose_version.decode() %}
+{% set cli_rose_version = cli_rose_version.replace('Rose ', '') %}  # strip the "Rose " prefix
+{% set cli_rose_version = cli_rose_version.split(' ')[0] %}  # strip the (location) suffix
+{% do LOG.info("$ rose version: " + cli_rose_version) %}
+{{ assert(ROSE_VERSION == cli_rose_version, "failed 5.2") }}
+
+# 6. CYLC_VERSION should be provided
+{{ assert(CYLC_VERSION is defined, "failed 6.1") }}
+{% set cli_cylc_version = Popen(["cylc", "version"], stdout=PIPE).communicate()[0] %}
+{% set cli_cylc_version = cli_cylc_version.decode() %}
+{% set cli_cylc_version = cli_cylc_version.strip() %}  # remove trailing newline
+{% do LOG.info("$ cylc version: " + cli_cylc_version) %}
+{{ assert(CYLC_VERSION == cli_cylc_version, "failed 6.2") }}
+
+# 7. ROSE_ORIG_HOST should be provided (hard to test it is set correctly here)
+{{ assert(ROSE_ORIG_HOST is defined, "failed 7.1") }}
+
+# 8. ROSE_SITE should be provided
+{{ assert(ROSE_SITE is defined, "failed 8.1") }}
+
+
+# chuck in some Cylc stuff to make validate happy
+[scheduling]
+    initial cycle point = now
+    [[dependencies]]
+        R1 = """
+            x
+        """
+
+[runtime]
+    [[x]]

--- a/tests/functional/09_template_vars_vanilla/processed.conf.control
+++ b/tests/functional/09_template_vars_vanilla/processed.conf.control
@@ -1,0 +1,27 @@
+# Test with rose `XYZ=xyz suite-run --new -l` (which invokes cylc validate --strict)
+# Rose env vars are logged to the console
+# 1. The Jinja2 shebang should be added automatically
+##
+ # cylc8
+# 2. ROSE_SUITE_VARIABLES should contain a mapping of all vars
+# 3. Env vars
+# 3.1 - Local env vars should be templated into rose-suite.conf[env]
+# 3.2 - rose-suite.conf[env] vars should be templated into rose-suite.conf[jinja2:suite.rc]
+# 3.3 - Escaped env vars should not be templated
+# 4. Literals should be evaluated
+# 5. ROSE_VERSION should be provided
+  # strip the "Rose " prefix
+  # strip the (location) suffix
+# 6. CYLC_VERSION should be provided
+  # remove trailing newline
+# 7. ROSE_ORIG_HOST should be provided (hard to test it is set correctly here)
+# 8. ROSE_SITE should be provided
+# chuck in some Cylc stuff to make validate happy
+[scheduling]
+    initial cycle point = now
+    [[dependencies]]
+        R1 = """
+            x
+        """
+[runtime]
+    [[x]]

--- a/tests/functional/09_template_vars_vanilla/rose-suite.conf
+++ b/tests/functional/09_template_vars_vanilla/rose-suite.conf
@@ -1,0 +1,10 @@
+[env]
+FOO=a
+
+[template variables]
+BAR="${FOO}b"
+LOCAL_ENV="$XYZ"
+ESCAPED_ENV="\$HOME"
+INT=42
+BOOL=True
+LIST=["a", 1, True]

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -42,8 +42,8 @@ def envar_exporter(dict_):
         (
             '08_template_engine_conflict',
             (
-                b'FileParseError: Plugins set templating engine = empy which '
-                b'does not match #!jinja2 set in flow.cylc.\n'
+                b'FileParseError: Plugins set templating engine = empy:'
+                b'suite.rc which does not match #!jinja2 set in flow.cylc.\n'
             )
         )
     ]
@@ -76,6 +76,7 @@ def test_validate_fail(srcdir, expect):
         ),
         ('06_jinja2_thorough', {'XYZ': 'xyz'}, None),
         ('07_cli_override', {'XYZ': ''}, ["--set=CLI_VAR='Wobble'"]),
+        ('09_template_vars_vanilla', {'XYZ': 'xyz'}, None),
     ],
 )
 def test_validate(tmp_path, srcdir, envvars, args):

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -42,8 +42,8 @@ def envar_exporter(dict_):
         (
             '08_template_engine_conflict',
             (
-                b'FileParseError: Plugins set templating engine = empy:'
-                b'suite.rc which does not match #!jinja2 set in flow.cylc.\n'
+                b'FileParseError: Plugins set templating engine = empy '
+                b'which does not match #!jinja2 set in flow.cylc.\n'
             )
         )
     ]


### PR DESCRIPTION
This PR plus [Cylc-flow PR 4073](https://github.com/cylc/cylc-flow/pull/4073) address #25.

Added functional test to ensure that this works properly.
Modified the logic ensuring the _only one_ template variables section is allowed.

Tests will fail online until [Cylc-flow PR 4073](https://github.com/cylc/cylc-flow/pull/4073) is merged.