### PR TITLE
Fix failure of non-rose workflows

### DIFF
--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -54,7 +54,8 @@ def post_install(srcdir=None, opts=None, rundir=None):
         srcdir=srcdir, opts=opts, rundir=rundir
     )
     # Finally dump a log of the rose-conf in its final state.
-    dump_rose_log(rundir=rundir, node=results['fileinstall'])
+    if results['fileinstall']:
+        dump_rose_log(rundir=rundir, node=results['fileinstall'])
 
     return results
 

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -44,6 +44,8 @@ def pre_configure(srcdir=None, opts=None, rundir=None):
 
 
 def post_install(srcdir=None, opts=None, rundir=None):
+    if not rose_config_exists(srcdir, opts):
+        return False
     srcdir, rundir = paths_to_pathlib([srcdir, rundir])
     results = {}
     copy_config_file(srcdir=srcdir, rundir=rundir)
@@ -158,9 +160,6 @@ def record_cylc_install_options(
         rose_suite_conf['opts'] - Opts section of the config node dumped to
         installed ``rose-suite.conf``.
     """
-    if not rose_config_exists(srcdir, opts):
-        return False
-
     # Create a config based on command line options:
     cli_config = get_cli_opts_node(opts)
 
@@ -212,10 +211,7 @@ def rose_fileinstall(srcdir=None, opts=None, rundir=None):
         rundir (pathlib.Path)
 
     """
-    if (
-        not rose_config_exists(srcdir, opts) or
-        not rose_config_exists(rundir, opts)
-    ):
+    if not rose_config_exists(rundir, opts):
         return False
 
     # Load the config tree

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+# THIS FILE IS PART OF THE ROSE-CYLC PLUGIN FOR THE CYLC SUITE ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Functional tests for top-level function record_cylc_install_options and
+"""
+
+import pytest
+
+from cylc.flow import __version__ as CYLC_VERSION
+
+
+@pytest.fixture(scope='package', autouse=True)
+def set_cylc_version():
+    from _pytest.monkeypatch import MonkeyPatch
+    mpatch = MonkeyPatch()
+    yield mpatch.setenv('CYLC_VERSION', CYLC_VERSION)
+    mpatch.undo()

--- a/tests/test_functional_post_install.py
+++ b/tests/test_functional_post_install.py
@@ -28,7 +28,7 @@ from types import SimpleNamespace
 from metomi.isodatetime.datetimeoper import DateTimeOperator
 
 from cylc.rose.entry_points import (
-    record_cylc_install_options, rose_fileinstall
+    record_cylc_install_options, rose_fileinstall, post_install
 )
 from metomi.rose.config import ConfigLoader
 
@@ -50,7 +50,7 @@ def assert_rose_conf_full_equal(left, right, no_ignore=True):
 
 
 def test_no_rose_suite_conf_in_devdir(tmp_path):
-    result = record_cylc_install_options(srcdir=tmp_path)
+    result = post_install(srcdir=tmp_path)
     assert result is False
 
 
@@ -283,7 +283,4 @@ def test_cylc_no_rose(tmp_path):
     """A Cylc workflow that contains no ``rose-suite.conf`` installs OK.
     """
     from cylc.rose.entry_points import post_install
-    assert post_install(srcdir=tmp_path, rundir=tmp_path) == {
-        'record_install': False,
-        'fileinstall': False
-    }
+    assert post_install(srcdir=tmp_path, rundir=tmp_path) is False

--- a/tests/test_functional_post_install.py
+++ b/tests/test_functional_post_install.py
@@ -277,3 +277,13 @@ def test_rose_fileinstall_exception(tmp_path, monkeypatch):
     (tmp_path / 'rose-suite.conf').touch()
     with pytest.raises(FileNotFoundError):
         rose_fileinstall(srcdir=tmp_path, rundir=tmp_path)
+
+
+def test_cylc_no_rose(tmp_path):
+    """A Cylc workflow that contains no ``rose-suite.conf`` installs OK.
+    """
+    from cylc.rose.entry_points import post_install
+    assert post_install(srcdir=tmp_path, rundir=tmp_path) == {
+        'record_install': False,
+        'fileinstall': False
+    }


### PR DESCRIPTION
sibling: https://github.com/cylc/cylc-flow/pull/4097

Cause: Cylc rose trying to dump config where config == False.
Fix: Prevent cylc-rose dumping config if config not present.