### PR TITLE
setup: load __version__ from package

### DIFF
--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
 Cylc Rose
 =========
 
@@ -122,3 +121,5 @@ See `the Rose Stem documentation
 <https://metomi.github.io/rose/2019.01.2/html/tutorial/rose/furthertopics/rose-stem.html>`_
 
 """
+
+__version__ = '0.1.0'

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS_REQUIRE['all'] = list(
 
 setup(
     name='cylc-rose',
-    version=__version__,
+    version=__version__,   # noqa
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@
 
 from setuptools import setup, find_namespace_packages
 
+# load __version__ number from the source
+exec(open('cylc/rose/__init__.py', 'r').read())
+
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -42,10 +45,9 @@ EXTRAS_REQUIRE['all'] = list(
     }
 ) + TESTS_REQUIRE
 
-
 setup(
     name='cylc-rose',
-    version='1.0.0',
+    version=__version__,
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
* Define the version number in the package.
  * This means we can do `cylc.rose.__version__`.
* Load this version number in the `setup.py` file.
  * This way we never get mismatching version numbers.
* Change the version from "1.0.0" to "0.1.0".
  * Use version "0" for code that is not production ready yet.
  * We will release version `1.0.0` to accompany Cylc `8.0.0` and Rose `2.0.0`.

```python
>>> import cylc.rose
>>> cylc.rose.__version__
'0.1.0'
```