### PR TITLE
Fix sphinx reference

### DIFF
--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -27,7 +27,7 @@ Rose Config
 -----------
 
 A fuller description of
-:rose:ref:`rose suite config is available here<Rose Suites>`.
+:ref:`rose suite config is available here<Rose Suites>`.
 
 Cylc-rose allows you to set environment and template variables in a
 configuration file called ``rose-suite.conf``. The following sections are


### PR DESCRIPTION
Attempt to fix this [cylc-doc nightly build error](https://github.com/cylc/cylc-doc/runs/2661115314?check_suite_focus=true):
```
Warning, treated as error: 
unknown directive or role name: rose:ref 
make: *** [Makefile:37: html] Error 2 
```
The build process worked locally for me before and after this change, so not sure what's going on. Possibly a backwards incompatible change in a new Sphinx version?