### PR TITLE
check root-dir

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,8 @@ jobs:
           flake8
 
       - name: Mypy
-        run: mypy --install-types
+        run: | 
+          yes| mypy --install-types
 
       - name: Test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           flake8
 
       - name: Mypy
-        run: mypy
+        run: mypy --install-types
 
       - name: Test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           flake8
 
       - name: Mypy
-        run: mypy --explicit-package-bases
+        run: mypy
 
       - name: Test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,8 +32,7 @@ jobs:
           flake8
 
       - name: Mypy
-        run: | 
-          yes| mypy --install-types
+        run: mypy
 
       - name: Test
         run: |

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -104,12 +104,7 @@ def get_rose_vars(srcdir=None, opts=None):
     # Load the raw config tree
     config_tree = rose_config_tree_loader(srcdir, opts)
     # Warn if root-dir set in config
-    old_rose_suite_run_config = (
-        config_tree.node.get_value(["rose-suite-run"]))
-    list_to_check = list(config_tree.node)
-    if old_rose_suite_run_config:
-        list_to_check.extend(list(old_rose_suite_run_config))
-    for string in list_to_check:
+    for string in list(config_tree.node):
         if 'root-dir' in string:
             LOG.warning(
                 'You have set "root-dir", which is not supported at '

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -103,13 +103,20 @@ def get_rose_vars(srcdir=None, opts=None):
 
     # Load the raw config tree
     config_tree = rose_config_tree_loader(srcdir, opts)
-
-    # Warn if root-dir set in config:
-    if 'root-dir' in config_tree.node:
-        LOG.warning(
-            'You have set "root-dir", which at Cylc 8 does nothing. '
-            'See Cylc Install documentation.'
-        )
+    # Warn if root-dir set in config
+    old_rose_suite_run_config = (
+        config_tree.node.get_value(["rose-suite-run"]))
+    list_to_check = list(config_tree.node)
+    if old_rose_suite_run_config:
+        list_to_check.extend(list(old_rose_suite_run_config))
+    for string in list_to_check:
+        if 'root-dir' in string:
+            LOG.warning(
+                'You have set "root-dir", which is not supported at '
+                'Cylc 8. Use `[install] symlink dirs` in global.cylc '
+                'instead.'
+                )
+            break
 
     # Extract templatevars from the configuration
     get_rose_vars_from_config_node(

--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -18,8 +18,8 @@
 from ast import literal_eval as python_literal_eval
 import re
 
-from jinja2.nativetypes import NativeEnvironment
-from jinja2.nodes import (
+from jinja2.nativetypes import NativeEnvironment  # type: ignore
+from jinja2.nodes import (  # type: ignore
     Literal,
     Output,
     Pair,

--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -123,6 +123,6 @@ class Parser(NativeEnvironment):
                     f'Invalid literal: {value}'
                     f'\n{type(node)}'
                 )
-            stack.extend([x for x in node.iter_child_nodes()])
+            stack.extend(list(node.iter_child_nodes()))
         # evaluate it
         return self.from_string('{{ %s }}' % value).render()

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -24,6 +24,7 @@ Provide a wrapper around "cylc install" for rose-stem suites.
 To run a rose-stem suite use "cylc play".
 """
 
+from contextlib import suppress
 import os
 import re
 import sys
@@ -175,7 +176,7 @@ class SuiteSelectionEvent(Event):
     __str__ = __repr__
 
 
-class StemRunner(object):
+class StemRunner:
 
     """Set up options for running a STEM job through Rose."""
 
@@ -224,9 +225,8 @@ class StemRunner(object):
             if ":" not in line:
                 continue
             key, value = line.split(":", 1)
-            if key:
-                if value:
-                    ret[key] = value.strip()
+            if key and value:
+                ret[key] = value.strip()
 
         return ret
 
@@ -278,10 +278,8 @@ class StemRunner(object):
         """
 
         project = None
-        try:
+        with suppress(ValueError):
             project, item = item.split("=", 1)
-        except ValueError:
-            pass
 
         if re.search(r'^\.', item):
             item = os.path.abspath(os.path.join(os.getcwd(), item))
@@ -341,17 +339,12 @@ class StemRunner(object):
             basedir = self.opts.stem_sources[0]
         else:
             basedir = self._ascertain_project(os.getcwd())[1]
-
         suitedir = os.path.join(basedir, DEFAULT_TEST_DIR)
         suitefile = os.path.join(suitedir, "rose-suite.conf")
-
-        if os.path.isfile(suitefile):
-            self.opts.suite = suitedir
-        else:
+        if not os.path.isfile(suitefile):
             raise RoseSuiteConfNotFoundException(suitedir)
-
+        self.opts.suite = suitedir
         self._check_suite_version(suitefile)
-
         return suitedir
 
     def _read_auto_opts(self):

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -387,7 +387,7 @@ class StemRunner(object):
         repos_with_hosts = {}
         if not self.opts.stem_sources:
             self.opts.stem_sources = ['.']
-        self.opts.project = list()
+        self.opts.project = []
 
         for i, url in enumerate(self.opts.stem_sources):
             project, url, base, rev, mirror = self._ascertain_project(url)

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -479,7 +479,7 @@ def simplify_opts_strings(opts):
     """
 
     seen_once = []
-    for index, item in enumerate(reversed(opts.split())):
+    for _index, item in enumerate(reversed(opts.split())):
         if item not in seen_once:
             seen_once.append(item)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,3 +6,4 @@ files = cylc/rose
 # Enable PEP 420 style namespace packages, which we use.
 # Needed for associating "import foo.bar" with foo/bar.py
 namespace_packages = True
+explicit_package_bases = True

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,13 @@ EXTRAS_REQUIRE = {
 }
 TESTS_REQUIRE = [
     'coverage>=5.0.0',
-    'flake8-*',
+    'flake8',
+    'flake8-broken-line>=0.3.0',
+    'flake8-bugbear>=21.0.0',
+    'flake8-builtins>=1.5.0',
+    'flake8-comprehensions>=3.5.0',
+    'flake8-debugger>=4.0.0',
+    'flake8-mutable>=1.2.0',
     'pytest',
     'pytest_cov',
 ]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@
 from setuptools import setup, find_namespace_packages
 
 # load __version__ number from the source
-exec(open('cylc/rose/__init__.py', 'r').read())
+with open('cylc/rose/__init__.py', 'r') as f:
+    exec(f.read())
 
 
 with open("README.md", "r") as fh:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ TESTS_REQUIRE = [
     'flake8',
     'pytest',
     'pytest_cov',
-    'types-Jinja2>=0.1.3',
+    'types-Jinja2',
 ]
 EXTRAS_REQUIRE['all'] = list(
     {

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ TESTS_REQUIRE = [
     'flake8',
     'pytest',
     'pytest_cov',
-    'types-Jinja2',
 ]
 EXTRAS_REQUIRE['all'] = list(
     {

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ TESTS_REQUIRE = [
     'flake8',
     'pytest',
     'pytest_cov',
+    'types-Jinja2>=0.1.3',
 ]
 EXTRAS_REQUIRE['all'] = list(
     {

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ EXTRAS_REQUIRE = {
 }
 TESTS_REQUIRE = [
     'coverage>=5.0.0',
-    'flake8',
+    'flake8-*',
     'pytest',
     'pytest_cov',
 ]

--- a/tests/functional/test_copy_config_file.py
+++ b/tests/functional/test_copy_config_file.py
@@ -54,7 +54,8 @@ def test_basic(tmp_path, sources, inputs, expect):
     # Test
     if expect:
         assert copy_config_file(**inputs) == expect
-        assert Path(tmp_path / 'src/rose-suite.conf').read_text() ==\
-            Path(tmp_path / 'dest/rose-suite.conf').read_text()
+        assert (Path(tmp_path / 'src/rose-suite.conf').read_text() ==
+                Path(tmp_path / 'dest/rose-suite.conf').read_text()
+                )
     else:
         assert copy_config_file(**inputs) == expect

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -124,12 +124,19 @@ def test_process(tmp_path, srcdir, envvars, args):
     assert expect == result
 
 
-def test_warn_if_root_dir_set(tmp_path, caplog):
-    (tmp_path / 'rose-suite.conf').write_text(
-        'root-dir="/the/only/path/ive/ever/known"\n'
-    )
+@pytest.mark.parametrize(
+    'root_dir_config', [
+        'root-dir="/the/only/path/ive/ever/known"\n',
+        'root-dir{work}="some/other/path"/n',
+        '[rose-suite-run]\nroot-dir="somepath"\n',
+        '[rose-suite-run]\nroot-dir{share/cycle}=*="some/share/cycle/path"\n'
+    ]
+)
+def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
+    """Test using unsupported root-dir config raises error."""
+    (tmp_path / 'rose-suite.conf').write_text(root_dir_config)
     get_rose_vars(srcdir=tmp_path)
     assert caplog.records[0].msg == (
-        'You have set "root-dir", which at Cylc 8 does nothing. '
-        'See Cylc Install documentation.'
+        'You have set "root-dir", which is not supported at Cylc 8. Use '
+        '`[install] symlink dirs` in global.cylc instead.'
     )

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -127,9 +127,7 @@ def test_process(tmp_path, srcdir, envvars, args):
 @pytest.mark.parametrize(
     'root_dir_config', [
         'root-dir="/the/only/path/ive/ever/known"\n',
-        'root-dir{work}="some/other/path"/n',
-        '[rose-suite-run]\nroot-dir="somepath"\n',
-        '[rose-suite-run]\nroot-dir{share/cycle}=*="some/share/cycle/path"\n'
+        'root-dir{work}="some/other/path"/n'
     ]
 )
 def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -89,16 +89,15 @@ def test_rose_fileinstall_subfolders(fixture_install_flow):
     """File installed into a sub directory:
     """
     _, datapath, _, _, destpath = fixture_install_flow
-    assert (destpath / 'runN/lib/python/lion.py').read_text() ==\
-        (datapath / 'lion.py').read_text()
+    assert ((destpath / 'runN/lib/python/lion.py').read_text() ==
+            (datapath / 'lion.py').read_text())
 
 
 def test_rose_fileinstall_concatenation(fixture_install_flow):
     """Multiple files concatenated on install (source contained wildcard):
     """
     _, datapath, _, _, destpath = fixture_install_flow
-    assert (destpath / 'runN/data').read_text() ==\
-        (
-            (datapath / 'randoms1.data').read_text() +
+    assert ((destpath / 'runN/data').read_text() ==
+            ((datapath / 'randoms1.data').read_text() +
             (datapath / 'randoms3.data').read_text()
-        )
+             ))

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -563,8 +563,9 @@ class TestIncompatibleVersions:
         """
 
         assert incompatible_versions.returncode == 1
-        assert b'Running rose-stem version 1 but suite is at version 0' in \
-            incompatible_versions.stderr
+        assert (b'Running rose-stem version 1 but suite is at version 0'
+                in incompatible_versions.stderr
+                )
 
 
 @pytest.fixture(scope='class')
@@ -592,5 +593,6 @@ class TestProjectNotInKeywords:
         """test for successful execution with site/user configuration
         """
         assert project_not_in_keywords.returncode == 1
-        assert b'Cannot ascertain project for source tree' in \
-            project_not_in_keywords.stderr
+        assert (b'Cannot ascertain project for source tree' in
+                project_not_in_keywords.stderr
+                )

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -126,7 +126,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
     node.set(['env', 'FOO'], '"The finger writes."')
     dump_rose_log(tmp_path, node)
     result = (tmp_path / 'log/conf/18151210T0000Z-rose-suite.conf').read_text()
-    assert '[env]\nFOO="The finger writes."\n' == result
+    assert result == '[env]\nFOO="The finger writes."\n'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -429,8 +429,9 @@ def test_cli_defines_ignored_are_ignored(
     )
 
     get_cli_opts_node(opts)
-    assert caplog.records[0].message == \
-        'CLI opts set to ignored or trigger-ignored will be ignored.'
+    assert (caplog.records[0].message ==
+            'CLI opts set to ignored or trigger-ignored will be ignored.'
+            )
 
 
 @pytest.mark.parametrize(
@@ -507,5 +508,6 @@ def test_merge_rose_cylc_suite_install_conf(old, new, expect):
     loader = ConfigLoader()
     old = loader.load(StringIO(old))
     new = loader.load(StringIO(new))
-    assert loader.load(StringIO(expect)) == \
-        merge_rose_cylc_suite_install_conf(old, new)
+    assert (loader.load(StringIO(expect)) ==
+            merge_rose_cylc_suite_install_conf(old, new)
+            )

--- a/tests/test_functional_post_install.py
+++ b/tests/test_functional_post_install.py
@@ -50,7 +50,7 @@ def assert_rose_conf_full_equal(left, right, no_ignore=True):
             node_1.comments != node_2.comments
         )
 
-    for keys_2, node_2 in right.walk(no_ignore=no_ignore):
+    for keys_2, _node_2 in right.walk(no_ignore=no_ignore):
         assert left.get(keys_2, no_ignore=no_ignore) is not None
 
 
@@ -84,8 +84,9 @@ def test_rose_fileinstall_uses_rose_template_vars(tmp_path):
     # Run both record_cylc_install options and fileinstall.
     record_cylc_install_options(opts=opts, rundir=destdir)
     rose_fileinstall(srcdir, opts, destdir)
-    assert (destdir / 'installedme').read_text() == \
-        'Galileo No! We will not let you go.'
+    assert ((destdir / 'installedme').read_text() ==
+            'Galileo No! We will not let you go.'
+            )
 
 
 @pytest.mark.parametrize(
@@ -231,10 +232,11 @@ def test_functional_record_cylc_install_options(
     loader = ConfigLoader()
 
     # Run the entry point top-level function:
-    rose_suite_cylc_install_node, rose_suite_opts_node = \
+    rose_suite_cylc_install_node, rose_suite_opts_node = (
         record_cylc_install_options(
             rundir=testdir, opts=opts, srcdir=testdir
         )
+    )
     rose_fileinstall(
         rundir=testdir, opts=opts, srcdir=testdir
     )
@@ -316,10 +318,11 @@ def test_template_section_conflict(
 
     with pytest.raises(MultipleTemplatingEnginesError) as exc_info:
         # Run the entry point top-level function:
-        rose_suite_cylc_install_node, rose_suite_opts_node = \
+        rose_suite_cylc_install_node, rose_suite_opts_node = (
             record_cylc_install_options(
                 rundir=testdir, opts=opts, srcdir=testdir
             )
+        )
     assert exc_info.match(expect)
 
 


### PR DESCRIPTION
Use of `root-dir` in a rose-suite.conf raises a warning. 
This PR also fixes the flake8 issues that were causing master to fail, and fixes mypy failure too with adding `--install-types` to the GH Actions mypy command.

To test `cylc install` a workflow with a rose-suite.conf containing root-dir config. This logic existed before but was skipping e.g.
 ```
root-dir{share/cycle}=$TMPDIR

