### PR TITLE
cylc-rose: `cylc list` compatibility

### DIFF
--- a/tests/functional/05_opts_set_from_rose_suite_conf/opt/rose-suite-Gaelige.conf
+++ b/tests/functional/05_opts_set_from_rose_suite_conf/opt/rose-suite-Gaelige.conf
@@ -1,8 +1,11 @@
 [jinja2:suite.rc]
 ICP=1
 FCP=1
-TASK1="cuir" # to put
-TASK2="tog"  # to lift
-TASK3="gabh" # to take
+# to put
+TASK1="cuir"
+# to lift
+TASK2="tog"
+# to take
+TASK3="gabh"
 MEMBERS=["control", "aon", "dhà", "trì"]
 SAMUELJOHNSON={"ein": 1, "zwei": 2, "drei": 3}

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -175,3 +175,41 @@ def test_cylc_list(monkeypatch, srcdir, option, envvars, expect):
     srcpath = Path(__file__).parent / srcdir
     output = run(split(f'cylc list {srcpath} {option}'), capture_output=True)
     assert expect in output.stdout
+
+
+@pytest.mark.parametrize(
+    'srcdir, option, envvars, expect',
+    [
+        pytest.param(
+            '05_opts_set_from_rose_suite_conf/flow.cylc', '',
+            {}, b'edge "mynd.1" "bwyta_dau.1"',
+            id='rose-suite.conf'
+        ),
+        pytest.param(
+            '05_opts_set_from_rose_suite_conf/flow.cylc', '-O Gaelige',
+            {}, b'edge "tog_tr\xc3\xac.1" "gabh.1"',
+            id='use -O'
+        ),
+        pytest.param(
+            '05_opts_set_from_rose_suite_conf/flow.cylc', '-D opts=""',
+            {}, b'edge "respond.1" "plunge_tan.1"',
+            id='use -D'
+        ),
+        pytest.param(
+            '05_opts_set_from_rose_suite_conf/', '',
+            {'ROSE_SUITE_OPT_CONF_KEYS': 'Gaelige'},
+            b'edge "gabh.1" "2_auf_deutsch_ist_zwei.1"',
+            id='use env variable to set option config'
+        ),
+    ]
+)
+def test_cylc_graph(monkeypatch, srcdir, option, envvars, expect):
+    """Cylc list can parse folders without installing."""
+    for name, value in envvars.items():
+        monkeypatch.setenv(name, value)
+    srcpath = Path(__file__).parent / srcdir
+    output = run(
+        split(f'cylc graph --reference {srcpath} {option}'),
+        capture_output=True
+    )
+    assert expect in output.stdout


### PR DESCRIPTION
Partial Response to https://github.com/cylc/cylc-flow/issues/4288
Twin of https://github.com/cylc/cylc-flow/pull/4293

Test to ensure that `cylc list` works correctly with Cylc Rose options.

Do not expect tests to pass without twin PR.