### PR TITLE
allow failure to set templating engine _anywhere_ to pass quietly.

### DIFF
--- a/tests/functional/10_reinstall_basic/flow.cylc
+++ b/tests/functional/10_reinstall_basic/flow.cylc
@@ -1,4 +1,3 @@
-#!jinja2
 [meta]
     title = "Workflow Filled in With info from ``rose-suite.conf``"
     description = """

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -39,7 +39,6 @@ def fixture_provide_flow(tmp_path):
 
     # Create source workflow:
     (srcpath / 'flow.cylc').write_text(
-        '#!jinja2\n'
         '[scheduling]\n'
         '    initial cycle point = 2020\n'
         '    [[dependencies]]\n'

--- a/tests/test_rose_opts.py
+++ b/tests/test_rose_opts.py
@@ -41,7 +41,6 @@ def fixture_provide_flow(tmp_path_factory):
 
     # Create source workflow:
     (srcpath / 'flow.cylc').write_text(
-        '#!jinja2\n'
         '[scheduling]\n'
         '    initial cycle point = 2020\n'
         '    [[graph]]\n'


### PR DESCRIPTION
This reverts commit abdcfd132e8daff94e3040ca88cc95f526f43c5e.

And therefore tests https://github.com/cylc/cylc-flow/pull/4360
**Test failure to be expected without this cylc-flow branch**