### PR TITLE
disabled capturing of stderr to allow us to see cause of failure in functional tests 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,7 @@ addopts = --verbose
     -n=1
     # group tests by module or class
     --dist=loadscope
+    # Disable stdout/err capturing so that we can see Cylc errors
+    -s
 testpaths =
     tests/


### PR DESCRIPTION
Closes #71 

Currently when functional test fails (often when it runs `cylc validate`) one has locate the pytest running that code and add breakpoints, even when the test failure relates to problems which are small or tangential to the feature in question.

By adding `-s` to the pytest option any failures will show the stdout from the commands run.

To test, try doing anything nasty (delete the runtime section/add an illegal config item/remove icp/change the name of a jinja2 template variable) to the `flow.cylc` in any of the functional test workflows and running the tests.

see also [Pytest docs: How to caputure stdout/err](https://pytest.org/en/latest/how-to/capture-stdout-stderr.html#setting-capturing-methods-or-disabling-capturing)