### PR TITLE
check CONTRIBUTING.md against mailmap

### DIFF
--- a/.github/workflows/1_create_release_pr.yml
+++ b/.github/workflows/1_create_release_pr.yml
@@ -24,6 +24,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ env.BASE_REF }}
+        fetch-depth: 0  # need to fetch all commits to check contributors
+
+    - name: Check CONTRIBUTING.md
+      uses: cylc/release-actions/check-shortlog@v1
 
     - name: Setup Python
       uses: actions/setup-python@v2

--- a/.github/workflows/shortlog.yml
+++ b/.github/workflows/shortlog.yml
@@ -1,0 +1,20 @@
+name: check contributor list
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'CONTRIBUTING.md'
+
+jobs:
+  test:
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # need to fetch all commits to check contributors
+
+      - name: Check CONTRIBUTING.md
+        uses: cylc/release-actions/check-shortlog@v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,13 @@ from outside of NIWA and the Met Office that predate the explicit introduction
 of this Agreement in July 2018; they must be un-parenthesised in future pull
 requests_).
 
+<!-- start-shortlog -->
  - Oliver Sanders
  - Tim Pillinger
  - Ronnie Dutta
  - Mel Hall
+ - Bruno P. Kinoshita
+<!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version
 control logs or otherwise.)


### PR DESCRIPTION
Closes #69 
Adds the following:
- A call to check shortlog action for each PR to ensure that people proactively update `CONTRIBUTING.md`.
- The same check in the creation of a release PR.

Similar to https://github.com/cylc/cylc-flow/pull/4205

To see the workflow run successfully see https://github.com/cylc/cylc-rose/runs/3359046877?check_suite_focus=true.

After a successful review and merge the reviewer should close the PR #82 and delete it's branch. Merging reviewer should also delete the `check-CONTRIBUTORS.md` branch which I used to test this work.