### PR TITLE
Add py.typed file and improve mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,7 @@ files = cylc/rose
 # Needed for associating "import foo.bar" with foo/bar.py
 namespace_packages = True
 explicit_package_bases = True
+
+allow_redefinition = True
+strict_equality = True
+show_error_codes = True


### PR DESCRIPTION
A blank `py.typed` file is needed in the package namespace otherwise some type checking might be skipped. Note that it must also be included in `setup.py` but it already is
https://github.com/cylc/cylc-rose/blob/9cd5448da318fa36fc95a4d5ab059dd185d3043b/setup.py#L63