### PR TITLE
Warn ROSE_VERSION in rose-suite.conf is ignored

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
             'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@master' \
           pip install ."[all]"
           git clone --depth 1 https://github.com/metomi/rose ../rose
+
           pip install -e ../rose[all]
 
       - name: Style
@@ -40,6 +41,39 @@ jobs:
 
       - name: Mypy
         run: mypy
+
+      - name: Checkout FCM
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.inputs.fcm_repo || 'metomi/fcm' }}
+          ref: ${{ github.event.inputs.fcm_ref || 'master' }}
+          path: 'fcm'
+
+      - name: Install FCM
+        run: |
+          # install FCM deps
+          sudo apt-get install -y \
+            subversion \
+            build-essential \
+            gfortran \
+            libxml-parser-perl \
+            libconfig-inifiles-perl \
+            libdbi-perl \
+            libdbd-sqlite3-perl
+
+          # install wandisco
+          sudo sh -c 'echo "deb http://opensource.wandisco.com/ubuntu \
+            `lsb_release -cs` svn19" \
+            >> /etc/apt/sources.list.d/subversion19.list'
+          sudo wget -q http://opensource.wandisco.com/wandisco-debian.gpg -O- \
+            | sudo apt-key add -
+
+          # prepend FCM bin to $PATH
+          FCM_PATH="$GITHUB_WORKSPACE/fcm/bin"
+          # the github actions way (needed for cylc jobs)
+          echo "$FCM_PATH" >> "${GITHUB_PATH}"
+          # the bashrc way (needed for subsequent gh action steps)
+          echo "export PATH=\"$FCM_PATH:\$PATH\"" >> "$HOME/.bashrc"
 
       - name: Test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,9 @@ jobs:
         run: |
           pip install \
             'cylc-flow[all] @ git+https://github.com/cylc/cylc-flow@master' \
-            'metomi-rose[all] @ git+https://github.com/metomi/rose@master'
           pip install ."[all]"
+          git clone --depth 1 https://github.com/metomi/rose ../rose
+          pip install -e ../rose[all]
 
       - name: Style
         run: |

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -17,9 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Rose. If not, see <http://www.gnu.org/licenses/>.
 # -----------------------------------------------------------------------------
-"""Cylc 8 implementation of 'rose stem'
-
-Provide a wrapper around "cylc install" for rose-stem suites.
+"""Install a rose-stem suite using cylc install.
 
 To run a rose-stem suite use "cylc play".
 """

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -92,7 +92,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             LOG.warning(
                 f'[{section}]ROSE_VERSION={user_rose_version.value} '
                 'from rose-suite.conf will be ignored: '
-                f'ROSE_VERSION set: {ROSE_VERSION}'
+                f'Using Rose: {ROSE_VERSION}'
             )
         config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
 
@@ -100,7 +100,8 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             user_cylc_version = config_node[section].value['CYLC_VERSION']
             LOG.warning(
                 f'[{section}]CYLC_VERSION={user_cylc_version.value} '
-                'from rose-suite.conf will be ignored.'
+                'from rose-suite.conf will be ignored: '
+                f'Using Cylc: {CYLC_VERSION}'
             )
         config_node[section].unset(['CYLC_VERSION'])
 

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -87,6 +87,13 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     for section in ['env', templating]:
         # Add standard ROSE_VARIABLES
         config_node[section].set(['ROSE_SITE'], rose_site)
+        if 'ROSE_VERSION' in config_node[section].value:
+            user_rose_version = config_node[section].value['ROSE_VERSION']
+            LOG.warning(
+                f'ROSE_VERSION {user_rose_version.value} '
+                'from rose-suite.conf will be ignored: '
+                f'ROSE_VERSION set: {ROSE_VERSION}'
+            )
         config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
         if rose_orig_host:
             config_node[section].set(['ROSE_ORIG_HOST'], rose_orig_host)

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -24,7 +24,7 @@ import shlex
 from typing import TYPE_CHECKING, Union
 
 from cylc.flow.hostuserutil import get_host
-from cylc.flow import LOG
+from cylc.flow import LOG, __version__ as CYLC_VERSION
 from cylc.rose.jinja2_parser import Parser
 from metomi.rose import __version__ as ROSE_VERSION
 from metomi.isodatetime.datetimeoper import DateTimeOperator

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -90,7 +90,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
         if 'ROSE_VERSION' in config_node[section].value:
             user_rose_version = config_node[section].value['ROSE_VERSION']
             LOG.warning(
-                f'ROSE_VERSION {user_rose_version.value} '
+                f'[{section}]ROSE_VERSION={user_rose_version.value} '
                 'from rose-suite.conf will be ignored: '
                 f'ROSE_VERSION set: {ROSE_VERSION}'
             )

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -95,6 +95,15 @@ def get_rose_vars_from_config_node(config, config_node, environ):
                 f'ROSE_VERSION set: {ROSE_VERSION}'
             )
         config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
+
+        if 'CYLC_VERSION' in config_node[section].value:
+            user_cylc_version = config_node[section].value['CYLC_VERSION']
+            LOG.warning(
+                f'[{section}]CYLC_VERSION={user_cylc_version.value} '
+                'from rose-suite.conf will be ignored.'
+            )
+        config_node[section].unset(['CYLC_VERSION'])
+
         if rose_orig_host:
             config_node[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,5 +81,5 @@ cylc.pre_configure =
     rose = cylc.rose.entry_points:pre_configure
 cylc.post_install =
     rose_opts = cylc.rose.entry_points:post_install
-console_scripts =
-    rose-stem = cylc.rose.stem:main
+rose.commands =
+    stem = cylc.rose.stem:main

--- a/tests/functional/06_jinja2_thorough/flow.cylc
+++ b/tests/functional/06_jinja2_thorough/flow.cylc
@@ -32,7 +32,7 @@
 {% do LOG.info("ROSE_VERSION from Cylc-rose is " + ROSE_VERSION) %}
 {% set cli_rose_version = Popen(["rose", "version"], stdout=PIPE).communicate()[0] %}
 {% set cli_rose_version = cli_rose_version.decode() %}
-{% set cli_rose_version = cli_rose_version.replace('Rose ', '') %}  # strip the "Rose " prefix
+{% set cli_rose_version = cli_rose_version.replace('rose ', '') %}  # strip the "Rose " prefix
 {% set cli_rose_version = cli_rose_version.split(' ')[0] %}  # strip the (location) suffix
 {% set cli_rose_version = cli_rose_version.strip() %}
 {% do LOG.info("rose version from CLI: " + cli_rose_version) %}

--- a/tests/functional/09_template_vars_vanilla/flow.cylc
+++ b/tests/functional/09_template_vars_vanilla/flow.cylc
@@ -32,7 +32,7 @@
 {{ assert(ROSE_VERSION is defined, "failed 5.1") }}
 {% set cli_rose_version = Popen(["rose", "version"], stdout=PIPE).communicate()[0] %}
 {% set cli_rose_version = cli_rose_version.decode() %}
-{% set cli_rose_version = cli_rose_version.replace('Rose ', '') %}  # strip the "Rose " prefix
+{% set cli_rose_version = cli_rose_version.replace('rose ', '') %}  # strip the "Rose " prefix
 {% set cli_rose_version = cli_rose_version.split(' ')[0] %}  # strip the (location) suffix
 {% set cli_rose_version = cli_rose_version.strip() %}
 {% do LOG.info("$ rose version: " + cli_rose_version) %}

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -24,25 +24,25 @@ Tests for cylc.rose.stem
 Structure
 ---------
 
-#. ``setup_stem_repo`` is a module scoped fixture which creates a Rose-Stem
+#. ``setup_stem_repo`` is a module scoped fixture which creates a Rose Stem
    repository which is used for all the tests.
 #. ``rose_stem_run_template`` is a class scoped fixture, which runs a rose
    stem command. Most of the tests are encapsulated in classes to allow
    this expensive fixture to be run only once per class. Most of the tests
-   check that the rose-stem has returned 0, and then check that variables
+   check that the ``rose stem`` has returned 0, and then check that variables
    have been written to a job file.
 #. For each test class there is a fixture encapsulating the test to be run.
 
 .. code::
 
     ┌───────┬──────────┬───────────┬───────────┬───────────────┐
-    │       │          │           │           │Test rose-stem │
-    │       │ test     │ rose-stem │ Class     │returned 0     │
+    │       │          │           │           │Test rose stem │
+    │       │ test     │ rose stem │ Class     │returned 0     │
     │set-up │ specific │ runner    │ container ├───────────────┤
     │repo   │ fixture  │ fixture   │           │Test for output│
     │fixture│ (set up  │           │ Only run  │strings "foo"  │
-    │       │ rose-stem│ (run      │ class     ├───────────────┤
-    │       │ command) │ rose-stem)│ fixture   │Test for output│
+    │       │ rose stem│ (run      │ class     ├───────────────┤
+    │       │ command) │ rose stem)│ fixture   │Test for output│
     │       │          │           │ once      │strings "bar"  │
     │       ├──────────┼─ ── ── ── ├───────────┼───────────────┤
     │       │          │           │           │               │
@@ -70,6 +70,9 @@ from shlex import split
 from uuid import uuid4
 
 from cylc.flow.pathutil import get_workflow_run_dir
+from cylc.flow.hostuserutil import get_host
+
+HOST = get_host().split('.')[0]
 
 
 class SubprocessesError(Exception):
@@ -231,7 +234,7 @@ def rose_stem_run_template(setup_stem_repo):
 @pytest.fixture(scope='class')
 def rose_stem_run_basic(rose_stem_run_template, setup_stem_repo):
     rose_stem_cmd = (
-        "rose-stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
+        "rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
         f"--source={setup_stem_repo['workingcopy']} "
         "--source=\"fcm:foo.x_tr\"@head "
         f"--flow-name {setup_stem_repo['suitename']}"
@@ -261,7 +264,7 @@ class TestBasic():
         else:
             expected = expected.format(
                 workingcopy=rose_stem_run_basic['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in rose_stem_run_basic['jobout_content']
 
@@ -271,7 +274,7 @@ def project_override(
     rose_stem_run_template, setup_stem_repo
 ):
     rose_stem_cmd = (
-        "rose-stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
+        "rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
         f"--source=bar={setup_stem_repo['workingcopy']} "
         "--source=fcm:foo.x_tr@head "
         f"--flow-name {setup_stem_repo['suitename']}"
@@ -309,7 +312,7 @@ class TestProjectOverride():
         else:
             expected = expected.format(
                 workingcopy=project_override['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in project_override['jobout_content']
 
@@ -319,7 +322,7 @@ def suite_redirection(
     rose_stem_run_template, setup_stem_repo
 ):
     rose_stem_cmd = (
-        "rose-stem --group=lapsang "
+        "rose stem --group=lapsang "
         f"-C {setup_stem_repo['workingcopy']}/rose-stem "
         "--source=\"fcm:foo.x_tr\"@head "
         f"--flow-name {setup_stem_repo['suitename']}"
@@ -346,7 +349,7 @@ class TestSuiteRedirection:
         else:
             expected = expected.format(
                 workingcopy=suite_redirection['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in suite_redirection['jobout_content']
 
@@ -356,7 +359,7 @@ def subdirectory(
     rose_stem_run_template, setup_stem_repo
 ):
     rose_stem_cmd = (
-        "rose-stem --group=assam "
+        "rose stem --group=assam "
         f"--source={setup_stem_repo['workingcopy']}/rose-stem "
         f"--flow-name {setup_stem_repo['suitename']}"
     )
@@ -385,7 +388,7 @@ class TestSubdirectory:
         else:
             expected = expected.format(
                 workingcopy=subdirectory['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in subdirectory['jobout_content']
 
@@ -395,7 +398,7 @@ def relative_path(
     rose_stem_run_template, setup_stem_repo
 ):
     rose_stem_cmd = (
-        f"rose-stem --group=ceylon -C rose-stem "
+        f"rose stem --group=ceylon -C rose-stem "
         f"--flow-name {setup_stem_repo['suitename']}"
     )
     yield rose_stem_run_template(rose_stem_cmd)
@@ -424,7 +427,7 @@ class TestRelativePath:
         else:
             expected = expected.format(
                 workingcopy=relative_path['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in relative_path['jobout_content']
 
@@ -436,7 +439,7 @@ def with_config(
     """test for successful execution with site/user configuration
     """
     rose_stem_cmd = (
-        "rose-stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
+        "rose stem --group=earl_grey --task=milk,sugar --group=spoon,cup,milk "
         f"--source={setup_stem_repo['workingcopy']} "
         "--source=fcm:foo.x_tr@head "
         f"--flow-name {setup_stem_repo['suitename']}"
@@ -477,7 +480,7 @@ class TestWithConfig:
         else:
             expected = expected.format(
                 workingcopy=with_config['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in with_config['jobout_content']
 
@@ -489,7 +492,7 @@ def with_config2(
     """test for successful execution with site/user configuration
     """
     rose_stem_cmd = (
-        "rose-stem --group=assam "
+        "rose stem --group=assam "
         f"--source={setup_stem_repo['workingcopy']}/rose-stem "
         f"--flow-name {setup_stem_repo['suitename']}"
     )
@@ -521,7 +524,7 @@ class TestWithConfig2:
         else:
             expected = expected.format(
                 workingcopy=with_config2['workingcopy'],
-                hostname=os.environ['HOSTNAME']
+                hostname=HOST
             )
             assert expected in with_config2['jobout_content']
 
@@ -536,7 +539,7 @@ def incompatible_versions(setup_stem_repo):
     )
     shutil.copy2(src, dest)
     rose_stem_cmd = (
-        "rose-stem --group=earl_grey "
+        "rose stem --group=earl_grey "
         "--task=milk,sugar"
         " --group=spoon,cup,milk "
         f"--source={setup_stem_repo['workingcopy']} "
@@ -573,7 +576,7 @@ def project_not_in_keywords(setup_stem_repo, monkeymodule):
     # Copy suite into working copy.
     monkeymodule.delenv('FCM_CONF_PATH')
     rose_stem_cmd = (
-        "rose-stem --group=earl_grey "
+        "rose stem --group=earl_grey "
         "--task=milk,sugar"
         " --group=spoon,cup,milk "
         f"--source={setup_stem_repo['workingcopy']} "

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -18,6 +18,7 @@
 import pytest
 
 from metomi.isodatetime.datetimeoper import DateTimeOperator
+from metomi.rose import __version__ as ROSE_VERSION
 from metomi.rose.config import (
     ConfigNode,
 )
@@ -65,6 +66,17 @@ def test_get_rose_vars_from_config_node__unbound_env_var(caplog):
     with pytest.raises(ConfigProcessError) as exc:
         get_rose_vars_from_config_node(ret, node, {})
     assert exc.match('env=X: MYVAR: unbound variable')
+
+
+def test_get_rose_vars_from_config_node__ignores_ROSE_VERSION(caplog):
+    """It should fail if variable unset in environment.
+    """
+    ret = {}
+    node = ConfigNode()
+    node.set(['template variables', 'ROSE_VERSION'], 99)
+    get_rose_vars_from_config_node(ret, node, {})
+    message = caplog.records[0].getMessage()
+    assert f'ROSE_VERSION set: {ROSE_VERSION}' in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
After doing some checks for #11 

`ROSE_VERSION` is ignored if set in `rose-suite.conf`. This PR adds a warning message for users that this is the case.
`CYLC_VERSION` is ignored by Cylc, and already has a warning message.

