### PR TITLE
changed are name 'flow_name' to 'workflow_name' in line with changed …

### DIFF
--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -447,7 +447,7 @@ class StemRunner:
             self.reporter(SuiteSelectionEvent(thissuite))
 
         # Create a default name for the suite; allow override by user
-        if not self.opts.flow_name:
+        if not self.opts.workflow_name:
             self.opts.flow_name = self._generate_name()
 
         return self.opts

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -448,7 +448,7 @@ class StemRunner:
 
         # Create a default name for the suite; allow override by user
         if not self.opts.workflow_name:
-            self.opts.flow_name = self._generate_name()
+            self.opts.workflow_name = self._generate_name()
 
         return self.opts
 


### PR DESCRIPTION
…name in cylc-flow

This is a small change fixing a bug caused by a change of internal name for a CLI option: Because the name had changed Cylc Rose wasn't able to properly interact with it.

Tiny change ⇒ Single review ticket.