### PR TITLE
setup: move project metadata to setup.cfg

### DIFF
--- a/MANIFEST.IN
+++ b/MANIFEST.IN
@@ -1,0 +1,1 @@
+include cylc/rose/py.typed

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -164,4 +164,4 @@ configuration file ``~/cylc-run/my_workflow/opt/rose-suite-cylc-install.conf``.
 
 """
 
-__version__ = '0.3.0'
+__version__ = '1.0.0.dev'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 author = British Crown (Met Office) & Contributors
 author_email = metomi@metoffice.gov.uk
-url=https://cylc.org/cylc-doc/latest/html/plugins/cylc-rose.html
+url=https://cylc.github.io/cylc-doc/latest/html/plugins/cylc-rose.html
 description = A Cylc plugin providing support for the Rose rose-suite.conf file.
 keywords =
     cylc

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,9 +16,12 @@
 
 [metadata]
 name = cylc-rose
+version = attr: cylc.rose.__version__
+long_description = file: README.md
+long_description_content_type = text/markdown
 author = British Crown (Met Office) & Contributors
 author_email = metomi@metoffice.gov.uk
-url=https://cylc.github.io/cylc-doc/latest/html/plugins/cylc-rose.html
+url=https://cylc.org/cylc-doc/latest/html/plugins/cylc-rose.html
 description = A Cylc plugin providing support for the Rose rose-suite.conf file.
 keywords =
     cylc
@@ -46,6 +49,32 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Atmospheric Science
 python_requires = >=3.7
+
+[options]
+packages = find_namespace:
+python_requires = >=3.7
+include_package_data = True
+install_requires =
+    metomi-rose==2.0b3
+    cylc-flow==8.0rc1.*  # the .* permits dev versions
+
+[options.packages.find]
+include = cylc*
+
+[options.extras_require]
+tests =
+    coverage>=5.0.0
+    flake8
+    flake8-broken-line>=0.3.0
+    flake8-bugbear>=21.0.0
+    flake8-builtins>=1.5.0
+    flake8-comprehensions>=3.5.0
+    flake8-debugger>=4.0.0
+    flake8-mutable>=1.2.0
+    pytest
+    pytest_cov
+all =
+    %(tests)s
 
 [options.entry_points]
 cylc.pre_configure =

--- a/setup.py
+++ b/setup.py
@@ -15,51 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from setuptools import setup, find_namespace_packages
+from setuptools import setup
 
-# load __version__ number from the source
-with open('cylc/rose/__init__.py', 'r') as f:
-    exec(f.read())
-
-
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
-
-INSTALL_REQUIRES = [
-    'metomi-rose==2.0b3',
-    'cylc-flow==8.0b3.*',  # the .* permits dev versions
-]
-EXTRAS_REQUIRE = {
-}
-TESTS_REQUIRE = [
-    'coverage>=5.0.0',
-    'flake8',
-    'flake8-broken-line>=0.3.0',
-    'flake8-bugbear>=21.0.0',
-    'flake8-builtins>=1.5.0',
-    'flake8-comprehensions>=3.5.0',
-    'flake8-debugger>=4.0.0',
-    'flake8-mutable>=1.2.0',
-    'pytest',
-    'pytest_cov',
-]
-EXTRAS_REQUIRE['all'] = list(
-    {
-        y
-        for x in EXTRAS_REQUIRE.values()
-        for y in x
-    }
-) + TESTS_REQUIRE
-
-setup(
-    name='cylc-rose',
-    version=__version__,   # noqa
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    install_requires=INSTALL_REQUIRES,
-    extras_require=EXTRAS_REQUIRE,
-    tests_require=TESTS_REQUIRE,
-    package_data={'cylc.rose': ['py.typed']},
-    packages=find_namespace_packages(include=["cylc.*"]),
-)
+setup()


### PR DESCRIPTION
* Move metadata from setup.py to setup.cfg for simplicity.
* Keep the setup.py file, when we are ready we can remove this to switch to PEP517 build.