### PR TITLE
Added a nightly test and a badge on the README to match

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   push:
     branches: [master]
+  schedule:
+    - cron: '53 0 * * *'
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cylc-Rose Plugin
 
+[![tests](https://github.com/cylc/cylc-rose/actions/workflows/tests.yml/badge.svg)](https://github.com/cylc/cylc-rose/actions/workflows/tests.yml)
+
 A [Cylc](https://github.com/cylc/cylc-flow) plugin providing support for the
 [Rose](https://github.com/metomi/rose) `rose-suite.conf` file.
 


### PR DESCRIPTION
For the second time in a week I've found a change in Rose or Cylc has broken Cylc Rose. 

Cylc Rose is designed to link Cylc and Rose and therefore is vulnerable to changes of plugin interface.

I want to know when this happens.