### PR TITLE
GH Actions: Edit test schedule

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [master]
   schedule:
-    - cron: '53 0 * * *'
+    - cron: '53 0 * * 1-5' # 00:53 Mon-Fri
 
 jobs:
   test:


### PR DESCRIPTION
I keep getting notifications whenever the tests fail on the scheduled run. This is because I merged the last PR that touched this line. If you merge this PR normally (i.e. not squash/rebase merge) then you should get the notifications from now on.