### PR TITLE
Small re-write of special variables docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ $ pip install -e cylc-rose[all]
 
 [![License](https://img.shields.io/github/license/cylc/cylc-flow.svg?color=lightgrey)](https://github.com/cylc/cylc-flow/blob/master/COPYING)
 
-Copyright (C) 2008-<span actions:bind='current-year'>2021</span> NIWA &
+Copyright (C) 2008-<span actions:bind='current-year'>2022</span> NIWA &
 British Crown (Met Office) & Contributors.
 
 Cylc-rose is free software: you can redistribute it and/or modify it under the terms

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -99,7 +99,7 @@ to the Cylc scheduler:
       ``ROSE_VERSION`` in your suite configuration it will be ignored.
 
 
-.. caution::
+.. deprecated:: 8.0.0
 
    ``CYLC_VERSION`` will be removed from your configuration by the
    Cylc-Rose plugin, as it is now set by Cylc.

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,7 +77,7 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   Cylc scripts (such as ``cylc validate`` and ``cylc play``)
+   Cylc commands (such as ``cylc validate`` and ``cylc play``)
    will provide the name of the host on which the script is run,
    unless the workflow has been installed using ``cylc install``.
    If this is the case the value set in
@@ -85,12 +85,12 @@ to the Cylc scheduler:
 
    .. caution::
 
-      Therefore, Cylc commands run on uninstalled workflows may produce
+      Therefore, running Cylc commands on non-installed workflows may produce
       inconsistent values for ``ROSE_ORIG_HOST``.
 
 
 ``ROSE_VERSION``
-   When running Cylc scripts such as ``cylc install``,
+   When running Cylc commands such as ``cylc install``,
    ``cylc play`` and ``cylc validate``
    the plugin provides the version number of your installed Rose Version in
    workflow scheduler's environment.

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -79,8 +79,9 @@ to the Cylc scheduler:
 ``ROSE_ORIG_HOST``
    Cylc scripts (such as ``cylc validate`` and ``cylc play``)
    will provide the name of the host on which the script is run,
-   unless the workflow has been installed using ``cylc install``. If this is
-   the case the value set in ``opt/rose-suite-cylc-install.conf`` will be used.
+   unless the workflow has been installed using ``cylc install``.
+   If this is the case the value set in
+   ``opt/rose-suite-cylc-install.conf`` will be used.
 
    .. caution::
 
@@ -89,7 +90,8 @@ to the Cylc scheduler:
 
 
 ``ROSE_VERSION``
-   When running Cylc scripts such as `cylc install`, `cylc play` and `cylc validate`
+   When running Cylc scripts such as ``cylc install``,
+   ``cylc play`` and ``cylc validate``
    the plugin provides the version number of your installed Rose Version in
    workflow scheduler's environment.
 

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,16 +77,16 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   Cylc commands (such as ``cylc validate`` and ``cylc play``)
-   will provide the name of the host on which the script is run,
-   unless the workflow has been installed using ``cylc install``.
-   If this is the case the value set in
-   ``opt/rose-suite-cylc-install.conf`` will be used.
+   Cylc commands (such as ``cylc install``, ``cylc validate`` and ``cylc play``)
+   will provide the name of the host on which the command is run.
 
-   .. caution::
+   If the workflow is installed the value of ``ROSE_ORIG_HOST`` will be
+   set in ``opt/rose-suite-cylc-install.conf`` and used by future commands
+   e.g. ``cylc play``.
 
-      Therefore, running Cylc commands on non-installed workflows may produce
-      inconsistent values for ``ROSE_ORIG_HOST``.
+   Using Cylc install should produce a more consistent value for
+   ``ROSE_ORIG_HOST``; running Cylc commands on uninstalled
+   workflows may produce inconsistent values.
 
 
 ``ROSE_VERSION``

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -88,7 +88,9 @@ to the Cylc scheduler:
 
 
 ``ROSE_VERSION``
-   The plugin provides the version number of your installed Rose Version.
+   When running Cylc scripts such as `cylc install`, `cylc play` and `cylc validate`
+   the plugin provides the version number of your installed Rose Version in
+   workflow scheduler's environment.
 
    .. deprecated:: 8.0.0
 

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,7 +77,8 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   Cylc scripts will provide the name of the host on which the script is run,
+   Cylc scripts (such as ``cylc validate`` and ``cylc play``)
+   will provide the name of the host on which the script is run,
    unless the workflow has been installed using ``cylc install``. If this is
    the case the value set in ``opt/rose-suite-cylc-install.conf`` will be used.
 

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -73,39 +73,28 @@ permitted in the ``rose-suite.conf`` files:
 Special Variables
 -----------------
 
-The Cylc Rose plugin has specific logic for handling a small group of special
-environment / template variables in the ``rose-suite.conf`` file:
+The Cylc Rose plugin provides two environment/template variables
+to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   The plugin provides the hostname of the computer where the plugin runs as
-   an evironment variable.
+   The plugin provides the hostname of the computer where the plugin runs.
 
 ``ROSE_VERSION``
-   The plugin provides ``ROSE_VERSION`` from your installed Rose Version
-   in the environment section and any templating sections you have defined.
+   The plugin provides the version number of your installed Rose Version.
 
    .. deprecated:: 8.0.0
 
       Setting ``[env]ROSE_VERSION`` in ``rose-suite.conf``.
 
-      With Cylc 7 / Rose2019 users could set ``ROSE_VERSION`` for thier
+      With Cylc 7 / Rose2019 users could set ``ROSE_VERSION`` for their
       suites. This is no longer possible, and if set in your
-      ``ROSE_VERSION`` in your suite configuration it will be overwritten.
+      ``ROSE_VERSION`` in your suite configuration it will be ignored.
 
-   you set ``ROSE_VERSION`` in your ``rose-suite.conf`` it will be replaced.
 
-``CYLC_VERSION``
-   The plugin will remove ``CYLC_VERSION`` from your config as it is provided
-   by Cylc's config processing.
+.. caution::
 
-   .. deprecated:: 8.0.0
-
-      Setting ``[env]CYLC_VERSION`` in ``rose-suite.conf``.
-
-      With Cylc 7 / Rose2019 users could set ``CYLC_VERSION`` for thier
-      suites. This is no longer possible, and if you set ``CYLC_VERSION``
-      in your suite configuration will be overwritten.
-
+   ``CYLC_VERSION`` will be removed from your configuration by the
+   Cylc-Rose plugin, as it is now set by Cylc.
 
 Additional CLI options
 ----------------------

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,18 +77,14 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   Cylc scripts will provide this as the name of the host the script is run
-   on, unless it is set in the ``[env]`` section of the configuration file.
-
-   ``cylc install`` will set ``ROSE_ORIG_HOST`` in
-   ``opt/rose-suite-cylc-install.conf``.
+   Cylc scripts will provide the name of the host on which the script is run,
+   unless the workflow has been installed using ``cylc install``. If this is
+   the case the value set in ``opt/rose-suite-cylc-install.conf`` will be used.
 
    .. caution::
 
-      Therefore, if you use ``cylc install``, ``ROSE_ORIG_HOST`` will always
-      be that computer for Cylc commands run on installed workflows.
-      Cylc commands run on uninstalled workflows may produce inconsistent
-      values.
+      Therefore, Cylc commands run on uninstalled workflows may produce
+      inconsistent values for ``ROSE_ORIG_HOST``.
 
 
 ``ROSE_VERSION``

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -98,16 +98,16 @@ to the Cylc scheduler:
    .. deprecated:: 8.0.0
 
       Setting ``[env]ROSE_VERSION`` in ``rose-suite.conf``.
-
       With Cylc 7 / Rose2019 users could set ``ROSE_VERSION`` for their
       suites. This is no longer possible, and if set in your
       ``ROSE_VERSION`` in your suite configuration it will be ignored.
 
 
-.. deprecated:: 8.0.0
+``CYLC_VERSION``
+   .. deprecated:: 8.0.0
 
-   ``CYLC_VERSION`` will be removed from your configuration by the
-   Cylc-Rose plugin, as it is now set by Cylc.
+      ``CYLC_VERSION`` will be removed from your configuration by the
+      Cylc-Rose plugin, as it is now set by Cylc.
 
 Additional CLI options
 ----------------------

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -86,7 +86,7 @@ to the Cylc scheduler:
    e.g. ``cylc play``.
 
    Using ``cylc install`` should produce a more consistent value
-   for ``ROSE_ORIG_HOST``; running Cylc commands on uninstalled
+   for ``ROSE_ORIG_HOST``; running Cylc commands on non-installed
    workflows may produce inconsistent values because the host
    is identified each time you run a command.
 

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,16 +77,18 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   Cylc commands (such as ``cylc install``, ``cylc validate`` and ``cylc play``)
+   Cylc commands (such as ``cylc install``, ``cylc validate`` and
+   ``cylc play``)
    will provide the name of the host on which the command is run.
 
    If the workflow is installed the value of ``ROSE_ORIG_HOST`` will be
    set in ``opt/rose-suite-cylc-install.conf`` and used by future commands
    e.g. ``cylc play``.
 
-   Using Cylc install should produce a more consistent value for
-   ``ROSE_ORIG_HOST``; running Cylc commands on uninstalled
-   workflows may produce inconsistent values.
+   Using ``cylc install`` should produce a more consistent value
+   for ``ROSE_ORIG_HOST``; running Cylc commands on uninstalled
+   workflows may produce inconsistent values because the host
+   is identified each time you run a command.
 
 
 ``ROSE_VERSION``

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -77,7 +77,19 @@ The Cylc Rose plugin provides two environment/template variables
 to the Cylc scheduler:
 
 ``ROSE_ORIG_HOST``
-   The plugin provides the hostname of the computer where the plugin runs.
+   Cylc scripts will provide this as the name of the host the script is run
+   on, unless it is set in the ``[env]`` section of the configuration file.
+
+   ``cylc install`` will set ``ROSE_ORIG_HOST`` in
+   ``opt/rose-suite-cylc-install.conf``.
+
+   .. caution::
+
+      Therefore, if you use ``cylc install``, ``ROSE_ORIG_HOST`` will always
+      be that computer for Cylc commands run on installed workflows.
+      Cylc commands run on uninstalled workflows may produce inconsistent
+      values.
+
 
 ``ROSE_VERSION``
    The plugin provides the version number of your installed Rose Version.

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from metomi.rose.config import ConfigLoader, ConfigDumper
 from cylc.rose.utilities import (
+    ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING,
     dump_rose_log,
     get_rose_vars_from_config_node,
     identify_templating_section,
@@ -195,6 +196,9 @@ def record_cylc_install_options(
     ]:
         if section in cli_config:
             cli_config[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
+            cli_config[section]['ROSE_ORIG_HOST'].comments = [
+                ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
+            ]
 
     cli_config.comments = [' This file records CLI Options.']
     identify_templating_section(cli_config)

--- a/cylc/rose/platform_utils.py
+++ b/cylc/rose/platform_utils.py
@@ -23,8 +23,8 @@ from typing import Dict, Any
 
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.exceptions import PlatformLookupError
+from cylc.flow.id_cli import parse_id
 from cylc.flow.rundb import CylcWorkflowDAO
-from cylc.flow.workflow_files import parse_reg
 from cylc.flow.platforms import get_platform
 
 
@@ -43,7 +43,7 @@ def get_platform_from_task_def(
     Returns:
         Platform Dictionary.
     """
-    _, flow_file = parse_reg(flow, src=True)
+    _, _, flow_file = parse_id(flow, constraint='workflows', src=True)
     config = WorkflowConfig(flow, flow_file, Values())
     # Get entire task spec to allow Cylc 7 platform from host guessing.
     task_spec = config.pcfg.get(['runtime', task])
@@ -72,7 +72,7 @@ def get_platforms_from_task_jobs(
     Returns:
         Platform Dictionary.
     """
-    _, flow_file = parse_reg(flow, src=True)
+    _, _, flow_file = parse_id(flow, constraint='workflows', src=True)
     dbfilepath = Path(flow_file).parent / '.service/db'
     dao = CylcWorkflowDAO(dbfilepath)
     task_platform_map: Dict = {}

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -569,8 +569,7 @@ def override_this_variable(node, section, variable):
     elif (
         variable != 'ROSE_ORIG_HOST'
         or (
-            variable in node[section]
-            and ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING not in
+            ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING not in
             node[section][variable].comments
         )
     ):

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
 
 SECTIONS = {'jinja2:suite.rc', 'empy:suite.rc', 'template variables'}
 SET_BY_CYLC = 'set by Cylc'
+ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING = (
+    ' ROSE_ORIG_HOST set by cylc install.'
+)
 
 
 class MultipleTemplatingEnginesError(Exception):
@@ -85,7 +88,23 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             ('ROSE_VERSION', ROSE_VERSION),
             ('CYLC_VERSION', SET_BY_CYLC)
         ]:
-            if var_name in config_node[section]:
+            if (
+                var_name in config_node[section]
+                and (
+                    (
+                        var_name == 'ROSE_ORIG_HOST'
+                        and (
+                            not config_node[section][var_name].comments
+                            or (
+                                config_node[section][var_name].comments[0]
+                                != ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
+                            )
+                        )
+                    ) or (
+                        var_name != 'ROSE_ORIG_HOST'
+                    )
+                )
+            ):
                 user_var = config_node[section].value[var_name]
                 LOG.warning(
                     f'[{section}]{var_name}={user_var.value} '

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -90,20 +90,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
         ]:
             if (
                 var_name in config_node[section]
-                and (
-                    (
-                        var_name == 'ROSE_ORIG_HOST'
-                        and (
-                            not config_node[section][var_name].comments
-                            or (
-                                config_node[section][var_name].comments[0]
-                                != ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
-                            )
-                        )
-                    ) or (
-                        var_name != 'ROSE_ORIG_HOST'
-                    )
-                )
+                and var_name != 'ROSE_ORIG_HOST'
             ):
                 user_var = config_node[section].value[var_name]
                 LOG.warning(
@@ -111,6 +98,18 @@ def get_rose_vars_from_config_node(config, config_node, environ):
                     'from rose-suite.conf will be ignored: '
                     f'{var_name} will be: {replace_with}'
                 )
+            elif (
+                var_name in config_node[section]
+                and ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING in
+                config_node[section][var_name].comments
+            ):
+                user_var = config_node[section].value[var_name]
+                LOG.warning(
+                    f'[{section}]{var_name}={user_var.value} '
+                    'from rose-suite.conf will be ignored: '
+                    f'{var_name} will be: {replace_with}'
+                )
+                replace_with = config_node[section].value[var_name].value
             if replace_with == SET_BY_CYLC:
                 config_node[section].unset([var_name])
             else:

--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -169,11 +169,8 @@ def test_cylc_validate_rundir(fixture_install_flow):
     validate = subprocess.run(
         ['cylc', 'validate', str(flowpath)], capture_output=True
     )
-    search = re.findall(
-        r'WARNING - ROSE_ORIG_HOST \(.*\) is: (.*)', validate.stderr.decode()
-    )
     assert validate.returncode == 0
-    assert search == ['foo', 'foo']
+    assert 'ROSE_ORIG_HOST (env) is:' in validate.stderr.decode()
 
 
 def test_cylc_install_run(fixture_install_flow):

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -29,6 +29,7 @@ At each step it checks the contents of
 
 import os
 import pytest
+import re
 import shutil
 import subprocess
 
@@ -127,17 +128,22 @@ def test_cylc_install_run(fixture_install_flow):
                 '!opts=b c\n'
                 f'\n[env]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
                 f'\n[template variables]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
             )
         )
     ]
 )
 def test_cylc_install_files(fixture_install_flow, file_, expect):
     fpath = fixture_install_flow['fixture_provide_flow']['flowpath']
-    assert (fpath / file_).read_text() == expect
+    result_text = re.sub(
+        'ROSE_ORIG_HOST=.*',
+        'ROSE_ORIG_HOST=<HOSTNAME>',
+        (fpath / file_).read_text()
+    )
+    assert result_text == expect
 
 
 @pytest.fixture(scope='module')
@@ -186,17 +192,22 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
                 '!opts=b c d\n'
                 f'\n[env]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
                 f'\n[template variables]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
             )
         )
     ]
 )
 def test_cylc_reinstall_files(fixture_reinstall_flow, file_, expect):
     fpath = fixture_reinstall_flow['fixture_provide_flow']['flowpath']
-    assert (fpath / file_).read_text() == expect
+    result_text = re.sub(
+        'ROSE_ORIG_HOST=.*',
+        'ROSE_ORIG_HOST=<HOSTNAME>',
+        (fpath / file_).read_text()
+    )
+    assert result_text == expect
 
 
 @pytest.fixture(scope='module')
@@ -250,17 +261,22 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
                 '!opts=b c d\n'
                 f'\n[env]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
                 f'\n[template variables]\n'
                 f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
             )
         )
     ]
 )
 def test_cylc_reinstall_files2(fixture_reinstall_flow2, file_, expect):
     fpath = fixture_reinstall_flow2['fixture_provide_flow']['flowpath']
-    assert (fpath / file_).read_text() == expect
+    result_text = re.sub(
+        'ROSE_ORIG_HOST=.*',
+        'ROSE_ORIG_HOST=<HOSTNAME>',
+        (fpath / file_).read_text()
+    )
+    assert result_text == expect
 
 
 def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path):

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -37,6 +37,8 @@ from uuid import uuid4
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
+from cylc.rose.utilities import (
+    ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING as ROHIOS)
 
 
 HOST = get_host()
@@ -124,8 +126,8 @@ def test_cylc_install_run(fixture_install_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
@@ -179,8 +181,8 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
@@ -239,8 +241,8 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -38,6 +38,7 @@ from uuid import uuid4
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
 
+from cylc.rose.utilities import ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
 
 HOST = get_host()
 
@@ -124,8 +125,12 @@ def test_cylc_install_run(fixture_install_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
@@ -179,8 +184,12 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
@@ -239,8 +248,12 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[env]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -29,7 +29,6 @@ At each step it checks the contents of
 
 import os
 import pytest
-import re
 import shutil
 import subprocess
 
@@ -39,7 +38,6 @@ from uuid import uuid4
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
 
-from cylc.rose.utilities import ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
 
 HOST = get_host()
 
@@ -126,24 +124,15 @@ def test_cylc_install_run(fixture_install_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c\n'
-                f'\n[env]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
-                f'\n[template variables]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
+                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
 )
 def test_cylc_install_files(fixture_install_flow, file_, expect):
     fpath = fixture_install_flow['fixture_provide_flow']['flowpath']
-    result_text = re.sub(
-        'ROSE_ORIG_HOST=.*',
-        'ROSE_ORIG_HOST=<HOSTNAME>',
-        (fpath / file_).read_text()
-    )
-    assert result_text == expect
+    assert (fpath / file_).read_text() == expect
 
 
 @pytest.fixture(scope='module')
@@ -190,24 +179,15 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
-                f'\n[template variables]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
+                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
 )
 def test_cylc_reinstall_files(fixture_reinstall_flow, file_, expect):
     fpath = fixture_reinstall_flow['fixture_provide_flow']['flowpath']
-    result_text = re.sub(
-        'ROSE_ORIG_HOST=.*',
-        'ROSE_ORIG_HOST=<HOSTNAME>',
-        (fpath / file_).read_text()
-    )
-    assert result_text == expect
+    assert (fpath / file_).read_text() == expect
 
 
 @pytest.fixture(scope='module')
@@ -259,24 +239,15 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
             'run1/opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
-                f'\n[env]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
-                f'\n[template variables]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST=<HOSTNAME>\n'
+                f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]
 )
 def test_cylc_reinstall_files2(fixture_reinstall_flow2, file_, expect):
     fpath = fixture_reinstall_flow2['fixture_provide_flow']['flowpath']
-    result_text = re.sub(
-        'ROSE_ORIG_HOST=.*',
-        'ROSE_ORIG_HOST=<HOSTNAME>',
-        (fpath / file_).read_text()
-    )
-    assert result_text == expect
+    assert (fpath / file_).read_text() == expect
 
 
 def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path):

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -37,6 +37,7 @@ from uuid import uuid4
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
+from cylc.rose.utilities import ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
 
 
 HOST = get_host()
@@ -111,8 +112,11 @@ def test_cylc_install_run(fixture_install_flow):
                 '!opts=bar\n\n'
                 '[env]\n'
                 'FOO=1\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
             )
         ),
     ]
@@ -164,8 +168,11 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
                 '!opts=baz\n\n'
                 '[env]\n'
                 'BAR=2\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n'
+                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                f'ROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -37,6 +37,8 @@ from uuid import uuid4
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
+from cylc.rose.utilities import (
+    ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING as ROHIOS)
 
 
 HOST = get_host()
@@ -110,9 +112,9 @@ def test_cylc_install_run(fixture_install_flow):
                 '# This file records CLI Options.\n\n'
                 '!opts=bar\n\n'
                 '[env]\n'
-                'FOO=1\n'
+                f'FOO=1\n#{ROHIOS}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
             )
         ),
     ]
@@ -163,9 +165,9 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
                 '# This file records CLI Options.\n\n'
                 '!opts=baz\n\n'
                 '[env]\n'
-                'BAR=2\n'
+                f'BAR=2\n#{ROHIOS}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -37,7 +37,6 @@ from uuid import uuid4
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
-from cylc.rose.utilities import ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
 
 
 HOST = get_host()
@@ -112,11 +111,8 @@ def test_cylc_install_run(fixture_install_flow):
                 '!opts=bar\n\n'
                 '[env]\n'
                 'FOO=1\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
             )
         ),
     ]
@@ -168,11 +164,8 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
                 '!opts=baz\n\n'
                 '[env]\n'
                 'BAR=2\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
                 f'ROSE_ORIG_HOST={HOST}\n'
-                f'\n[template variables]\n'
-                f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
-                f'ROSE_ORIG_HOST={HOST}\n'
+                f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
             )
         )
     ]

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -24,7 +24,6 @@ from metomi.rose.config import (
 )
 from metomi.rose.config_processor import ConfigProcessError
 
-from cylc.flow import __version__ as CYLC_VERSION
 from cylc.rose.utilities import (
     get_rose_vars_from_config_node,
     add_cylc_install_to_rose_conf_node_opts,
@@ -89,7 +88,7 @@ def test_get_vars_from_config_node__ignores_user_ROSE_VERSION(
     override_version_vars
 ):
     """It should warn that user ROSE_VERSION will be changed."""
-    assert f'Using Rose: {ROSE_VERSION}' in override_version_vars[1]
+    assert f'ROSE_VERSION will be: {ROSE_VERSION}' in override_version_vars[1]
 
 
 def test_get_vars_from_config_node__sets_right_ROSE_VERSION(
@@ -104,7 +103,7 @@ def test_get_vars_from_config_node__ignores_user_CYLC_VERSION(
     override_version_vars
 ):
     """It should warn that user CYLC_VERSION will be unset."""
-    assert f'Using Cylc: {CYLC_VERSION}' in override_version_vars[1]
+    assert 'CYLC_VERSION will be: set by Cylc' in override_version_vars[1]
 
 
 def test_get_vars_from_config_node__unsets_CYLC_VERSION(

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -239,3 +239,10 @@ def test_identify_templating_section(node_, expect, raises):
     if raises is not None:
         with pytest.raises(raises):
             identify_templating_section(node)
+
+
+def test_ROSE_ORIG_HOST_replacement_behaviour():
+    ret = {}
+    node = ConfigNode()
+    node.set(['env', 'ROSE_ORIG_HOST'], 99)
+    breakpoint()

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -209,10 +209,10 @@ def test_get_rose_vars_ROSE_VARS(tmp_path):
     """Test that rose variables are available in the environment section.."""
     (tmp_path / "rose-suite.conf").touch()
     rose_vars = get_rose_vars(tmp_path)
-    assert list(rose_vars['env'].keys()) == [
+    assert list(rose_vars['env'].keys()).sort() == [
         'ROSE_ORIG_HOST',
         'ROSE_VERSION',
-    ]
+    ].sort()
 
 
 def test_get_rose_vars_jinja2_ROSE_VARS(tmp_path):
@@ -223,11 +223,11 @@ def test_get_rose_vars_jinja2_ROSE_VARS(tmp_path):
     rose_vars = get_rose_vars(tmp_path)
     assert list(rose_vars['template_variables'][
         'ROSE_SUITE_VARIABLES'
-    ].keys()) == [
-        'ROSE_ORIG_HOST',
+    ].keys()).sort() == [
         'ROSE_VERSION',
+        'ROSE_ORIG_HOST',
         'ROSE_SUITE_VARIABLES'
-    ]
+    ].sort()
 
 
 def test_get_rose_vars_fail_if_empy_AND_jinja2(tmp_path):

--- a/tests/test_functional_post_install.py
+++ b/tests/test_functional_post_install.py
@@ -31,7 +31,10 @@ from cylc.flow.hostuserutil import get_host
 from cylc.rose.entry_points import (
     record_cylc_install_options, rose_fileinstall, post_install
 )
-from cylc.rose.utilities import MultipleTemplatingEnginesError
+from cylc.rose.utilities import (
+    ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING,
+    MultipleTemplatingEnginesError
+)
 from metomi.rose.config import ConfigLoader
 
 
@@ -110,8 +113,12 @@ def test_rose_fileinstall_uses_rose_template_vars(tmp_path):
                 'test/opt/rose-suite-foo.conf': '',
                 'ref/opt/rose-suite-cylc-install.conf': (
                     'opts=\n[env]\nFOO=1'
-                    f'\n[template variables]\nX=Y\nROSE_ORIG_HOST={HOST}\n'
-                    f'\n[env]\nROSE_ORIG_HOST={HOST}\n'
+                    f'\n[template variables]\nX=Y\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
+                    f'\n[env]\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
                 ),
                 'ref/rose-suite.conf': '!opts=foo (cylc-install)',
                 'ref/opt/rose-suite-foo.conf': '',
@@ -140,8 +147,12 @@ def test_rose_fileinstall_uses_rose_template_vars(tmp_path):
                     '\n[template variables]\nROSE_ORIG_HOST=abc123\n'
                 ),
                 'ref/opt/rose-suite-cylc-install.conf':
-                    f'!opts=bar baz\n[env]\nBAR=2\nROSE_ORIG_HOST={HOST}\n'
-                    f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n',
+                    f'!opts=bar baz\n[env]\nBAR=2\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
+                    f'\n[template variables]\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n',
                 'ref/rose-suite.conf': '!opts=foo bar baz (cylc-install)',
                 'ref/opt/rose-suite-foo.conf': '',
                 'ref/opt/rose-suite-bar.conf': '',
@@ -166,8 +177,12 @@ def test_rose_fileinstall_uses_rose_template_vars(tmp_path):
                 'test/opt/rose-suite-b.conf': '',
                 'test/opt/rose-suite-c.conf': '',
                 'ref/opt/rose-suite-cylc-install.conf': (
-                    f'!opts=b c\n\n[env]\nROSE_ORIG_HOST={HOST}\n'
-                    f'\n[template variables]\nROSE_ORIG_HOST={HOST}\n'
+                    f'!opts=b c\n\n[env]\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
+                    f'\n[template variables]\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
                 ),
                 'ref/rose-suite.conf': '!opts=a b c (cylc-install)',
                 'ref/opt/rose-suite-a.conf': '',
@@ -192,8 +207,12 @@ def test_rose_fileinstall_uses_rose_template_vars(tmp_path):
                 'test/opt/rose-suite-foo.conf': '[jinja2:suite.rc]\ny="f"\n',
                 'test/opt/rose-suite-bar.conf': '[jinja2:suite.rc]\ny="b"\n',
                 'ref/opt/rose-suite-cylc-install.conf': (
-                    f'!opts=foo bar\n[env]\na=b\nROSE_ORIG_HOST={HOST}\n'
-                    f'[jinja2:suite.rc]\na="b"\nROSE_ORIG_HOST={HOST}\n'
+                    f'!opts=foo bar\n[env]\na=b\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
+                    f'[jinja2:suite.rc]\na="b"\n'
+                    f'#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n'
+                    f'ROSE_ORIG_HOST={HOST}\n'
                 ),
                 'ref/rose-suite.conf': (
                     '!opts=foo bar (cylc-install)\n[jinja2:suite.rc]\ny="base"'

--- a/tests/test_rose_opts.py
+++ b/tests/test_rose_opts.py
@@ -27,6 +27,8 @@ from uuid import uuid4
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
 
+from cylc.rose.utilities import ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING
+
 
 @pytest.fixture(scope='module')
 def fixture_provide_flow(tmp_path_factory):
@@ -105,10 +107,12 @@ def test_rose_fileinstall_rose_suite_cylc_install_conf(fixture_install_flow):
         "!opts=A B\n\n"
         "[env]\n"
         "FOO=42\n"
+        f"#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n"
         f"ROSE_ORIG_HOST={host}\n\n"
         "[jinja2:suite.rc]\n"
         "BAR=84\n"
         "CORNETTO=120\n"
         "FLAKE=99\n"
+        f"#{ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING}\n"
         f"ROSE_ORIG_HOST={host}\n"
     )


### PR DESCRIPTION
Follow up #104 
- [x] Fix spelling mistakes (i before e except in their).
- [x] Re-write.

Ended up with massive mission creep:

### Summary of discussion with @dpmatthews  and @oliver-sanders 

Cylc Rose should do the following with ROSE_ORIG_HOST:
- Annotate the config item in `rose-suite-cylc-install.conf` to indicate that the install process saved this config.
- Use the saved ROSE_ORIG_HOST for installed workflows.
- Make ROSE_ORIG_HOST the hostname of the machine running the script otherwise, warning the user that any value which they may have set will be over-ridden.