### PR TITLE
Rose orig host should warn if set in config and be over ridden

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -75,13 +75,20 @@ def get_rose_vars_from_config_node(config, config_node, environ):
         config_node.set([templating])
 
     # Get Rose Orig host if it's not in definition.
-    rose_orig_host = None
-    if 'ROSE_ORIG_HOST' not in config_node['env']:
-        rose_orig_host = get_host()
+    rose_orig_host = get_host()
 
     # Get Values for standard ROSE variable ROSE_ORIG_HOST.
     # For each section process variables and add standard variables.
     for section in ['env', templating]:
+        if 'ROSE_ORIG_HOST' in config_node[section]:
+            user_rose_orig_host = config_node[section].value['ROSE_ORIG_HOST']
+            LOG.warning(
+                f'[{section}]ROSE_VERSION={user_rose_orig_host.value} '
+                'from rose-suite.conf will be ignored: '
+                f'Using Rose: {rose_orig_host}'
+            )
+        config_node[section].set(['ROSE_VERSION'], rose_orig_host)
+
         # Add standard ROSE_VARIABLES
         if 'ROSE_VERSION' in config_node[section].value:
             user_rose_version = config_node[section].value['ROSE_VERSION']

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -24,7 +24,7 @@ import shlex
 from typing import TYPE_CHECKING, Union
 
 from cylc.flow.hostuserutil import get_host
-from cylc.flow import LOG, __version__ as CYLC_VERSION
+from cylc.flow import LOG
 from cylc.rose.jinja2_parser import Parser
 from metomi.rose import __version__ as ROSE_VERSION
 from metomi.isodatetime.datetimeoper import DateTimeOperator
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 
 
 SECTIONS = {'jinja2:suite.rc', 'empy:suite.rc', 'template variables'}
+SET_BY_CYLC = 'set by Cylc'
 
 
 class MultipleTemplatingEnginesError(Exception):
@@ -74,42 +75,27 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     if templating not in config_node.value:
         config_node.set([templating])
 
-    # Get Rose Orig host if it's not in definition.
+    # Get Rose Orig host:
     rose_orig_host = get_host()
 
-    # Get Values for standard ROSE variable ROSE_ORIG_HOST.
     # For each section process variables and add standard variables.
     for section in ['env', templating]:
-        if 'ROSE_ORIG_HOST' in config_node[section]:
-            user_rose_orig_host = config_node[section].value['ROSE_ORIG_HOST']
-            LOG.warning(
-                f'[{section}]ROSE_VERSION={user_rose_orig_host.value} '
-                'from rose-suite.conf will be ignored: '
-                f'Using Rose: {rose_orig_host}'
-            )
-        config_node[section].set(['ROSE_VERSION'], rose_orig_host)
-
-        # Add standard ROSE_VARIABLES
-        if 'ROSE_VERSION' in config_node[section].value:
-            user_rose_version = config_node[section].value['ROSE_VERSION']
-            LOG.warning(
-                f'[{section}]ROSE_VERSION={user_rose_version.value} '
-                'from rose-suite.conf will be ignored: '
-                f'Using Rose: {ROSE_VERSION}'
-            )
-        config_node[section].set(['ROSE_VERSION'], ROSE_VERSION)
-
-        if 'CYLC_VERSION' in config_node[section].value:
-            user_cylc_version = config_node[section].value['CYLC_VERSION']
-            LOG.warning(
-                f'[{section}]CYLC_VERSION={user_cylc_version.value} '
-                'from rose-suite.conf will be ignored: '
-                f'Using Cylc: {CYLC_VERSION}'
-            )
-        config_node[section].unset(['CYLC_VERSION'])
-
-        if rose_orig_host:
-            config_node[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
+        for var_name, replace_with in [
+            ('ROSE_ORIG_HOST', rose_orig_host),
+            ('ROSE_VERSION', ROSE_VERSION),
+            ('CYLC_VERSION', SET_BY_CYLC)
+        ]:
+            if var_name in config_node[section]:
+                user_var = config_node[section].value[var_name]
+                LOG.warning(
+                    f'[{section}]{var_name}={user_var.value} '
+                    'from rose-suite.conf will be ignored: '
+                    f'{var_name} will be: {replace_with}'
+                )
+            if replace_with == SET_BY_CYLC:
+                config_node[section].unset([var_name])
+            else:
+                config_node[section].set([var_name], replace_with)
 
         # Use env_var_process to process variables which may need expanding.
         for key, node in config_node.value[section].value.items():

--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -169,11 +169,8 @@ def test_cylc_validate_rundir(fixture_install_flow):
     validate = subprocess.run(
         ['cylc', 'validate', str(flowpath)], capture_output=True
     )
-    search = re.findall(
-        r'WARNING - ROSE_ORIG_HOST \(.*\) is: (.*)', validate.stderr.decode()
-    )
     assert validate.returncode == 0
-    assert search == ['foo', 'foo']
+    assert 'ROSE_ORIG_HOST (env) is:' in validate.stderr.decode()
 
 
 def test_cylc_install_run(fixture_install_flow):

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -24,7 +24,6 @@ from metomi.rose.config import (
 )
 from metomi.rose.config_processor import ConfigProcessError
 
-from cylc.flow import __version__ as CYLC_VERSION
 from cylc.rose.utilities import (
     get_rose_vars_from_config_node,
     add_cylc_install_to_rose_conf_node_opts,
@@ -89,7 +88,7 @@ def test_get_vars_from_config_node__ignores_user_ROSE_VERSION(
     override_version_vars
 ):
     """It should warn that user ROSE_VERSION will be changed."""
-    assert f'Using Rose: {ROSE_VERSION}' in override_version_vars[1]
+    assert f'ROSE_VERSION will be: {ROSE_VERSION}' in override_version_vars[1]
 
 
 def test_get_vars_from_config_node__sets_right_ROSE_VERSION(
@@ -104,7 +103,7 @@ def test_get_vars_from_config_node__ignores_user_CYLC_VERSION(
     override_version_vars
 ):
     """It should warn that user CYLC_VERSION will be unset."""
-    assert f'Using Cylc: {CYLC_VERSION}' in override_version_vars[1]
+    assert 'CYLC_VERSION will be: set by Cylc' in override_version_vars[1]
 
 
 def test_get_vars_from_config_node__unsets_CYLC_VERSION(

--- a/tests/test_config_tree.py
+++ b/tests/test_config_tree.py
@@ -209,10 +209,10 @@ def test_get_rose_vars_ROSE_VARS(tmp_path):
     """Test that rose variables are available in the environment section.."""
     (tmp_path / "rose-suite.conf").touch()
     rose_vars = get_rose_vars(tmp_path)
-    assert list(rose_vars['env'].keys()) == [
+    assert list(rose_vars['env'].keys()).sort() == [
         'ROSE_ORIG_HOST',
         'ROSE_VERSION',
-    ]
+    ].sort()
 
 
 def test_get_rose_vars_jinja2_ROSE_VARS(tmp_path):
@@ -223,11 +223,11 @@ def test_get_rose_vars_jinja2_ROSE_VARS(tmp_path):
     rose_vars = get_rose_vars(tmp_path)
     assert list(rose_vars['template_variables'][
         'ROSE_SUITE_VARIABLES'
-    ].keys()) == [
-        'ROSE_ORIG_HOST',
+    ].keys()).sort() == [
         'ROSE_VERSION',
+        'ROSE_ORIG_HOST',
         'ROSE_SUITE_VARIABLES'
-    ]
+    ].sort()
 
 
 def test_get_rose_vars_fail_if_empy_AND_jinja2(tmp_path):


### PR DESCRIPTION
Responds to an issue discovered whilst inspecting code:

At the moment Cylc Rose defers to `rose-suite.conf` when deciding whether to set `ROSE_ORIG_HOST`: The plugin should always over-ride this, warning the user if it has done so.

This may close https://github.com/cylc/cylc-rose/issues/105