### PR TITLE
add explict deps for isdatetime and jinja2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,8 @@ include_package_data = True
 install_requires =
     metomi-rose==2.0rc2.*  # the .* permits dev versions
     cylc-flow==8.0rc2.*  # the .* permits dev versions
+    metomi-isodatetime
+    jinja2
 
 [options.packages.find]
 include = cylc*


### PR DESCRIPTION
## Summary

This is a small change with no associated Issue.

`isodatetime` and `jinja2` are used explicitly and should be included in the setuptools spec. They are critical dependencies for `cylc-flow`, so must be very loosely pinned to avoid conflict with Cylc Flow.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Does not need tests (dep change)
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
