### PR TITLE
Make test_pre_configure[template engine conflict] less specific

### DIFF
--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -45,7 +45,7 @@ def envar_exporter(dict_):
         ),
         param(
             '08_template_engine_conflict',
-            b'TemplateVarLanguageClash: .*= empy.* #!jinja2.*',
+            b'TemplateVarLanguageClash: .*empy.*#!jinja2.*',
             id='template engine conflict'
         )
     ]

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -151,7 +151,7 @@ def test_add_cylc_install_to_rose_conf_node_opts(rose_conf, cli_conf, expect):
 
     expect_opt = ''
     if 'opts' in cli_conf:
-        expect_opt = cli_conf['opts']
+        expect_opt = cli_conf.get('opts')
     expect_opt += ' (cylc-install)'
 
     assert result.comments == [(


### PR DESCRIPTION
to allow changed Parsec error message to be accepted by the test.

Broken by [this comment](https://github.com/cylc/cylc-flow/pull/4720#discussion_r816516651) in #4720.

This is a small change with no associated Issue.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Does not need tests (itself a test change).
- [x] No change log entry required - test fix.
- [x] No documentation update required.
