### PR TITLE
Pre configure not handling rose template variables properly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
 [130](https://github.com/cylc/cylc-rose/pull/130) - Fix bug preventing
 ``cylc reinstall`` using Rose fileinstall.
 
+[132](https://github.com/cylc/cylc-rose/pull/132) - Fix bug preventing
+Cylc commands (other than `install`) from accessing the content of
+`--rose-template-variable`.
 
 ## __cylc-rose-1.0.2 (<span actions:bind='release-date'>Released 2022-03-24</span>)__
 

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -253,7 +253,7 @@ def rose_config_tree_loader(srcdir=None, opts=None):
     # Reload the Config using the suite_ variables.
     # (we can't do this first time around because we have no idea what the
     # templating section is.)
-    if opts and 'rose_template_vars' in dir(opts) and opts.rose_template_vars:
+    if getattr(opts, 'rose_template_vars', None):
         template_section = identify_templating_section(config_tree.node)
         for template_var in opts.rose_template_vars:
             redefinitions.append(f'[{template_section}]{template_var}')

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -170,7 +170,6 @@ def get_rose_vars_from_config_node(config, config_node, environ):
 
 
 def identify_templating_section(config_node):
-
     defined_sections = SECTIONS.intersection(set(config_node.value.keys()))
     if (
         'jinja2:suite.rc' in defined_sections
@@ -250,6 +249,21 @@ def rose_config_tree_loader(srcdir=None, opts=None):
         opt_keys=opt_conf_keys,
         defines=redefinitions,
     )
+
+    # Reload the Config using the suite_ variables.
+    # (we can't do this first time around because we have no idea what the
+    # templating section is.)
+    if opts and 'rose_template_vars' in dir(opts) and opts.rose_template_vars:
+        template_section = identify_templating_section(config_tree.node)
+        for template_var in opts.rose_template_vars:
+            redefinitions.append(f'[{template_section}]{template_var}')
+        # Reload the config
+        config_tree = ConfigTreeLoader().load(
+            str(srcdir),
+            'rose-suite.conf',
+            opt_keys=opt_conf_keys,
+            defines=redefinitions,
+        )
 
     return config_tree
 


### PR DESCRIPTION
These changes close #121  and #122

## Synopsis

The pre_configure step was not handling `cylc command -S`/`--rose-template-variable` command line option: This wasn't a problem with the `cylc install; cylc play workflow`, because the post_install step would handle this variable saving it to `opt/rose-suite-cylc-install.conf` from whence it would be picked up by `cylc play`. This meant that:
- It was possible to install variables with illegal values (#121). 
- It was impossible to validate, dump &c workflows reliant on template variables supplied by `-S` (#122).

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.

## Review
@dpmatthews  Tagged as discoverer of these bugs.