### PR TITLE
Fix.do not allow multiple templating sections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
 [130](https://github.com/cylc/cylc-rose/pull/130) - Fix bug preventing
 ``cylc reinstall`` using Rose fileinstall.
 
+[133](https://github.com/cylc/cylc-rose/pull/133) - Fix bug allowing setting
+multiple template variable sections.
 
 ## __cylc-rose-1.0.2 (<span actions:bind='release-date'>Released 2022-03-24</span>)__
 

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -27,7 +27,6 @@ from pathlib import Path
 from metomi.rose.config import ConfigLoader, ConfigDumper
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING,
-    SECTIONS,
     dump_rose_log,
     get_rose_vars_from_config_node,
     identify_templating_section,
@@ -210,7 +209,9 @@ def record_cylc_install_options(
 
     # Get Values for standard ROSE variable ROSE_ORIG_HOST.
     rose_orig_host = get_host()
-    for section in SECTIONS:
+    for section in [
+        'env', 'jinja2:suite.rc', 'empy:suite.rc', 'template variables'
+    ]:
         if section in cli_config:
             cli_config[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
             cli_config[section]['ROSE_ORIG_HOST'].comments = [

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from metomi.rose.config import ConfigLoader, ConfigDumper
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING,
+    SECTIONS,
     dump_rose_log,
     get_rose_vars_from_config_node,
     identify_templating_section,
@@ -209,9 +210,7 @@ def record_cylc_install_options(
 
     # Get Values for standard ROSE variable ROSE_ORIG_HOST.
     rose_orig_host = get_host()
-    for section in [
-        'env', 'jinja2:suite.rc', 'empy:suite.rc', 'template variables'
-    ]:
+    for section in SECTIONS:
         if section in cli_config:
             cli_config[section].set(['ROSE_ORIG_HOST'], rose_orig_host)
             cli_config[section]['ROSE_ORIG_HOST'].comments = [

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -170,12 +170,8 @@ def get_rose_vars_from_config_node(config, config_node, environ):
 
 
 def identify_templating_section(config_node):
-
     defined_sections = SECTIONS.intersection(set(config_node.value.keys()))
-    if (
-        'jinja2:suite.rc' in defined_sections
-        and 'empy:suite.rc' in defined_sections
-    ):
+    if len(defined_sections) > 1:
         raise MultipleTemplatingEnginesError(
             "You should not define more than one templating section. "
             f"You defined:\n\t{'; '.join(defined_sections)}"

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -36,10 +36,7 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-JINJA2_SECTION = 'jinja2:suite.rc'
-EMPY_SECTION = 'empy:suite.rc'
-TEMPLATE_VARIABLES = 'template variables'
-SECTIONS = {JINJA2_SECTION, EMPY_SECTION, TEMPLATE_VARIABLES}
+SECTIONS = {'jinja2:suite.rc', 'empy:suite.rc', 'template variables'}
 SET_BY_CYLC = 'set by Cylc'
 ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING = (
     ' ROSE_ORIG_HOST set by cylc install.'
@@ -70,7 +67,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     # Don't allow multiple templating sections.
     templating = identify_templating_section(config_node)
 
-    if templating != TEMPLATE_VARIABLES:
+    if templating != 'template variables':
         config['templating_detected'] = templating.replace(':suite.rc', '')
     else:
         config['templating_detected'] = templating
@@ -140,10 +137,10 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             item[0][1]: item[1].value for item in
             config_node.value[templating].walk()
         }
-    elif TEMPLATE_VARIABLES in config_node.value:
+    elif 'template variables' in config_node.value:
         config['template_variables'] = {
             item[0][1]: item[1].value for item in
-            config_node.value[TEMPLATE_VARIABLES].walk()
+            config_node.value['template variables'].walk()
         }
 
     # Add the entire config to ROSE_SUITE_VARIABLES to allow for programatic
@@ -179,12 +176,12 @@ def identify_templating_section(config_node):
             "You should not define more than one templating section. "
             f"You defined:\n\t{'; '.join(defined_sections)}"
         )
-    elif JINJA2_SECTION in defined_sections:
-        templating = JINJA2_SECTION
-    elif EMPY_SECTION in defined_sections:
-        templating = EMPY_SECTION
+    elif 'jinja2:suite.rc' in defined_sections:
+        templating = 'jinja2:suite.rc'
+    elif 'empy:suite.rc' in defined_sections:
+        templating = 'empy:suite.rc'
     else:
-        templating = TEMPLATE_VARIABLES
+        templating = 'template variables'
 
     return templating
 
@@ -356,7 +353,7 @@ def get_cli_opts_node(opts=None, srcdir=None):
         config_node = rose_config_tree_loader(srcdir, opts).node
         templating = identify_templating_section(config_node)
     else:
-        templating = TEMPLATE_VARIABLES
+        templating = 'template variables'
 
     for define in rose_template_vars:
         match = re.match(

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -36,7 +36,10 @@ if TYPE_CHECKING:
     from optparse import Values
 
 
-SECTIONS = {'jinja2:suite.rc', 'empy:suite.rc', 'template variables'}
+JINJA2_SECTION = 'jinja2:suite.rc'
+EMPY_SECTION = 'empy:suite.rc'
+TEMPLATE_VARIABLES = 'template variables'
+SECTIONS = {JINJA2_SECTION, EMPY_SECTION, TEMPLATE_VARIABLES}
 SET_BY_CYLC = 'set by Cylc'
 ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING = (
     ' ROSE_ORIG_HOST set by cylc install.'
@@ -67,7 +70,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     # Don't allow multiple templating sections.
     templating = identify_templating_section(config_node)
 
-    if templating != 'template variables':
+    if templating != TEMPLATE_VARIABLES:
         config['templating_detected'] = templating.replace(':suite.rc', '')
     else:
         config['templating_detected'] = templating
@@ -137,10 +140,10 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             item[0][1]: item[1].value for item in
             config_node.value[templating].walk()
         }
-    elif 'template variables' in config_node.value:
+    elif TEMPLATE_VARIABLES in config_node.value:
         config['template_variables'] = {
             item[0][1]: item[1].value for item in
-            config_node.value['template variables'].walk()
+            config_node.value[TEMPLATE_VARIABLES].walk()
         }
 
     # Add the entire config to ROSE_SUITE_VARIABLES to allow for programatic
@@ -176,12 +179,12 @@ def identify_templating_section(config_node):
             "You should not define more than one templating section. "
             f"You defined:\n\t{'; '.join(defined_sections)}"
         )
-    elif 'jinja2:suite.rc' in defined_sections:
-        templating = 'jinja2:suite.rc'
-    elif 'empy:suite.rc' in defined_sections:
-        templating = 'empy:suite.rc'
+    elif JINJA2_SECTION in defined_sections:
+        templating = JINJA2_SECTION
+    elif EMPY_SECTION in defined_sections:
+        templating = EMPY_SECTION
     else:
-        templating = 'template variables'
+        templating = TEMPLATE_VARIABLES
 
     return templating
 
@@ -353,7 +356,7 @@ def get_cli_opts_node(opts=None, srcdir=None):
         config_node = rose_config_tree_loader(srcdir, opts).node
         templating = identify_templating_section(config_node)
     else:
-        templating = 'template variables'
+        templating = TEMPLATE_VARIABLES
 
     for define in rose_template_vars:
         match = re.match(

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -216,7 +216,16 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             None,
             MultipleTemplatingEnginesError,
-            id="FAILS - clashing template sections set",
+            id="FAILS - empy and jinja2 sections set",
+        ),
+        pytest.param(
+            (
+                (['empy:suite.rc', 'foo'], 'Hello World'),
+                (['template variables', 'foo'], 'Hello World'),
+            ),
+            None,
+            MultipleTemplatingEnginesError,
+            id="FAILS - empy and template variables sections set",
         ),
         pytest.param(
             (


### PR DESCRIPTION
These changes close #124 

## Synopsis

Cylc Rose was checking for `[empy:suite.rc]` and `[jinja2:suite.rc]` both being set, but was not checking whether either was being set with `[template variables]`.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.

## Other

Tagging @dpmatthews for a functional review as he raised this bug. IMO this only requires 1 full review +1 manual test.
