### PR TITLE
Log warning [jinja2/empy:suite.rc] is deprecated

### DIFF
--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from metomi.rose.config import ConfigLoader, ConfigDumper
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING,
+    deprecation_warnings,
     dump_rose_log,
     get_rose_vars_from_config_node,
     identify_templating_section,
@@ -37,7 +38,6 @@ from cylc.rose.utilities import (
     get_cli_opts_node,
     add_cylc_install_to_rose_conf_node_opts,
 )
-from cylc.flow import LOG
 from cylc.flow.hostuserutil import get_host
 
 
@@ -136,33 +136,6 @@ def get_rose_vars(srcdir=None, opts=None):
         os.environ[key] = val
 
     return config
-
-
-def deprecation_warnings(config_tree):
-    """Check for deprecated items in config.
-    Logs a warning for deprecated items:
-        - "root-dir"
-        - "jinja2:suite.rc"
-        - "empy:suite.rc"
-
-    """
-
-    deprecations = {
-        'empy:suite.rc': (
-            "'empy:suite.rc' is deprecated."
-            " Use [template variables] instead."),
-        'jinja2:suite.rc': (
-            "'jinja2:suite.rc' is deprecated."
-            " Use [template variables] instead."),
-        'root-dir': (
-            'You have set "root-dir", which is not supported at '
-            'Cylc 8. Use `[install] symlink dirs` in global.cylc '
-            'instead.')
-    }
-    for string in list(config_tree.node):
-        for deprecation in deprecations.keys():
-            if deprecation in string:
-                LOG.warning(deprecations[deprecation])
 
 
 def record_cylc_install_options(

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -219,7 +219,7 @@ def record_cylc_install_options(
             ]
 
     cli_config.comments = [' This file records CLI Options.']
-    identify_templating_section(cli_config)
+    identify_templating_section(cli_config, noisy=True)
     dumper.dump(cli_config, str(conf_filepath))
 
     # Merge the opts section of the rose-suite.conf with those set by CLI:
@@ -229,7 +229,7 @@ def record_cylc_install_options(
     rose_suite_conf = add_cylc_install_to_rose_conf_node_opts(
         rose_suite_conf, cli_config
     )
-    identify_templating_section(rose_suite_conf)
+    identify_templating_section(rose_suite_conf, noisy=True)
     dumper(rose_suite_conf, rose_conf_filepath)
 
     return cli_config, rose_suite_conf

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -169,7 +169,8 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             'ROSE_SUITE_VARIABLES'] = config['template_variables']
 
 
-def identify_templating_section(config_node):
+def identify_templating_section(config_node, noisy=False):
+
     defined_sections = SECTIONS.intersection(set(config_node.value.keys()))
     if len(defined_sections) > 1:
         raise MultipleTemplatingEnginesError(
@@ -178,8 +179,18 @@ def identify_templating_section(config_node):
         )
     elif 'jinja2:suite.rc' in defined_sections:
         templating = 'jinja2:suite.rc'
+        if noisy:
+            LOG.warning(
+                "[jinja2:suite.rc] is deprecated."
+                " Use [template variables] instead."
+            )
     elif 'empy:suite.rc' in defined_sections:
         templating = 'empy:suite.rc'
+        if noisy:
+            LOG.warning(
+                "[empy:suite.rc] is deprecated."
+                " Use [template variables] instead."
+            )
     else:
         templating = 'template variables'
 

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -169,7 +169,7 @@ def get_rose_vars_from_config_node(config, config_node, environ):
             'ROSE_SUITE_VARIABLES'] = config['template_variables']
 
 
-def identify_templating_section(config_node, noisy=False):
+def identify_templating_section(config_node):
 
     defined_sections = SECTIONS.intersection(set(config_node.value.keys()))
     if len(defined_sections) > 1:
@@ -179,18 +179,8 @@ def identify_templating_section(config_node, noisy=False):
         )
     elif 'jinja2:suite.rc' in defined_sections:
         templating = 'jinja2:suite.rc'
-        if noisy:
-            LOG.warning(
-                "[jinja2:suite.rc] is deprecated."
-                " Use [template variables] instead."
-            )
     elif 'empy:suite.rc' in defined_sections:
         templating = 'empy:suite.rc'
-        if noisy:
-            LOG.warning(
-                "[empy:suite.rc] is deprecated."
-                " Use [template variables] instead."
-            )
     else:
         templating = 'template variables'
 

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -170,7 +170,6 @@ def get_rose_vars_from_config_node(config, config_node, environ):
 
 
 def identify_templating_section(config_node):
-
     defined_sections = SECTIONS.intersection(set(config_node.value.keys()))
     if len(defined_sections) > 1:
         raise MultipleTemplatingEnginesError(
@@ -604,3 +603,30 @@ def rose_orig_host_set_by_cylc_install(node, section, var):
     ):
         return True
     return False
+
+
+def deprecation_warnings(config_tree):
+    """Check for deprecated items in config.
+    Logs a warning for deprecated items:
+        - "root-dir"
+        - "jinja2:suite.rc"
+        - "empy:suite.rc"
+
+    """
+
+    deprecations = {
+        'empy:suite.rc': (
+            "'empy:suite.rc' is deprecated."
+            " Use [template variables] instead."),
+        'jinja2:suite.rc': (
+            "'jinja2:suite.rc' is deprecated."
+            " Use [template variables] instead."),
+        'root-dir': (
+            'You have set "root-dir", which is not supported at '
+            'Cylc 8. Use `[install] symlink dirs` in global.cylc '
+            'instead.')
+    }
+    for string in list(config_tree.node):
+        for deprecation in deprecations.keys():
+            if deprecation in string:
+                LOG.warning(deprecations[deprecation])

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -141,6 +141,20 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
 
 
 @pytest.mark.parametrize(
+    'rose_config', [
+        '[empy:suite.rc]',
+        '[jinja2:suite.rc]'
+    ]
+)
+def test_warn_if_old_templating_set(rose_config, tmp_path, caplog):
+    """Test using unsupported root-dir config raises error."""
+    (tmp_path / 'rose-suite.conf').write_text(rose_config)
+    get_rose_vars(srcdir=tmp_path)
+    msg = "is deprecated. Use [template variables]"
+    assert msg in caplog.records[0].message
+
+
+@pytest.mark.parametrize(
     'opts',
     [
         SimpleNamespace(opt_conf_keys=['Foo']),

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -175,7 +175,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    'node_, expect, raises',
+    'node_, expect, raises, warning',
     [
         pytest.param(
             (
@@ -183,6 +183,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
+            False,
             id="OK - template variables",
         ),
         pytest.param(
@@ -191,6 +192,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'jinja2:suite.rc',
             None,
+            True,
             id="OK - jinja2:suite.rc",
         ),
         pytest.param(
@@ -199,6 +201,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'empy:suite.rc',
             None,
+            True,
             id="OK - empy:suite.rc",
         ),
         pytest.param(
@@ -207,6 +210,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
+            False,
             id="OK - no template variables section set",
         ),
         pytest.param(
@@ -216,6 +220,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             None,
             MultipleTemplatingEnginesError,
+            False,
             id="FAILS - empy and jinja2 sections set",
         ),
         pytest.param(
@@ -225,6 +230,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             None,
             MultipleTemplatingEnginesError,
+            False,
             id="FAILS - empy and template variables sections set",
         ),
         pytest.param(
@@ -234,16 +240,20 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
+            False,
             id="OK - No interference with irrelevant sections",
         ),
     ]
 )
-def test_identify_templating_section(node_, expect, raises):
+def test_identify_templating_section(node_, expect, raises, warning, caplog):
     node = ConfigNode()
     for item in node_:
         node.set(item[0], item[1])
     if expect is not None:
-        assert identify_templating_section(node) == expect
+        assert identify_templating_section(node, noisy=True) == expect
+    if warning:
+        msg = "is deprecated. Use [template variables]"
+        assert msg in caplog.records[0].message
     if raises is not None:
         with pytest.raises(raises):
             identify_templating_section(node)

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -175,7 +175,7 @@ def test_dump_rose_log(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    'node_, expect, raises, warning',
+    'node_, expect, raises',
     [
         pytest.param(
             (
@@ -183,7 +183,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
-            False,
             id="OK - template variables",
         ),
         pytest.param(
@@ -192,7 +191,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'jinja2:suite.rc',
             None,
-            True,
             id="OK - jinja2:suite.rc",
         ),
         pytest.param(
@@ -201,7 +199,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'empy:suite.rc',
             None,
-            True,
             id="OK - empy:suite.rc",
         ),
         pytest.param(
@@ -210,7 +207,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
-            False,
             id="OK - no template variables section set",
         ),
         pytest.param(
@@ -220,7 +216,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             None,
             MultipleTemplatingEnginesError,
-            False,
             id="FAILS - empy and jinja2 sections set",
         ),
         pytest.param(
@@ -230,7 +225,6 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             None,
             MultipleTemplatingEnginesError,
-            False,
             id="FAILS - empy and template variables sections set",
         ),
         pytest.param(
@@ -240,20 +234,16 @@ def test_dump_rose_log(monkeypatch, tmp_path):
             ),
             'template variables',
             None,
-            False,
             id="OK - No interference with irrelevant sections",
         ),
     ]
 )
-def test_identify_templating_section(node_, expect, raises, warning, caplog):
+def test_identify_templating_section(node_, expect, raises):
     node = ConfigNode()
     for item in node_:
         node.set(item[0], item[1])
     if expect is not None:
-        assert identify_templating_section(node, noisy=True) == expect
-    if warning:
-        msg = "is deprecated. Use [template variables]"
-        assert msg in caplog.records[0].message
+        assert identify_templating_section(node) == expect
     if raises is not None:
         with pytest.raises(raises):
             identify_templating_section(node)


### PR DESCRIPTION

These changes close https://github.com/cylc/cylc-rose/issues/123

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (why? e.g. only a warning).
- [x] No documentation update required.
