### PR TITLE
Small Changes to location of `log/x/___-rose-suite.conf`

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -524,9 +524,9 @@ def dump_rose_log(rundir, node):
     """
     dumper = ConfigDumper()
     timestamp = DateTimeOperator().process_time_point_str(
-        print_format='%Y%m%dT%H%M%S%Z'
+        print_format='%Y%m%dT%H%M%S%z'
     )
-    rel_path = f'log/conf/{timestamp}-rose-suite.conf'
+    rel_path = f'log/config/{timestamp}-rose-suite.conf'
     fpath = rundir / rel_path
     fpath.parent.mkdir(exist_ok=True, parents=True)
     dumper.dump(node, str(fpath))

--- a/tests/test_config_node.py
+++ b/tests/test_config_node.py
@@ -170,7 +170,8 @@ def test_dump_rose_log(monkeypatch, tmp_path):
     node = ConfigNode()
     node.set(['env', 'FOO'], '"The finger writes."')
     dump_rose_log(tmp_path, node)
-    result = (tmp_path / 'log/conf/18151210T0000Z-rose-suite.conf').read_text()
+    result = (
+        tmp_path / 'log/config/18151210T0000Z-rose-suite.conf').read_text()
     assert result == '[env]\nFOO="The finger writes."\n'
 
 


### PR DESCRIPTION
#### Changes
- dump rose-suite.conf in log/config not log/conf
- ensure that log/config/<timestamp>-rose-suite.conf includes a time-zone

#### Admin

- Closes #135
- Deliberately not done anything which might be addressed in #134 
- Only asking for a single review because it's a very small change.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Already covered by existing tests.
- [x] Does not need tests (why?).
- [x] No change log entry required (Pre-release change to log dir, should be invisible to all but a few select test users).
- [x] No documentation update required.
