### PR TITLE
Updated tests to use the new Cylc install CLI syntax:

### DIFF
--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -115,9 +115,8 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     """
     result = subprocess.run(
         [
-            'cylc', 'install',
-            '--flow-name', fixture_provide_flow['test_flow_name'],
-            '-C', str(fixture_provide_flow['srcpath'])
+            'cylc', 'install', str(fixture_provide_flow['srcpath']),
+            '--workflow-name', fixture_provide_flow['test_flow_name'],
         ],
         capture_output=True,
         env=os.environ

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -211,6 +211,6 @@ def test_cylc_script(monkeypatch, option, envvars, cmd, expect):
     for name, value in envvars.items():
         monkeypatch.setenv(name, value)
     srcpath = Path(__file__).parent / (
-        '05_opts_set_from_rose_suite_conf/flow.cylc')
+        '05_opts_set_from_rose_suite_conf')
     output = run(split(f'{cmd} {srcpath} {option}'), capture_output=True)
     assert expect in output.stdout

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -88,9 +88,8 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     monkeymodule.setenv('ROSE_SUITE_OPT_CONF_KEYS', 'b')
     result = subprocess.run(
         [
-            'cylc', 'install', '-O', 'c',
-            '--flow-name', fixture_provide_flow['test_flow_name'],
-            '-C', str(fixture_provide_flow['srcpath'])
+            'cylc', 'install', str(fixture_provide_flow['srcpath']), '-O', 'c',
+            '--workflow-name', fixture_provide_flow['test_flow_name'],
         ],
         capture_output=True,
         env=os.environ
@@ -264,7 +263,7 @@ def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path):
     test_flow_name = f'cylc-rose-test-{str(uuid4())[:8]}'
     install = subprocess.run(
         [
-            'cylc', 'install', '-C', str(tmp_path), '--flow-name',
+            'cylc', 'install', str(tmp_path), '--workflow-name',
             test_flow_name, '--no-run-name'
         ]
     )

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -88,8 +88,8 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     result = subprocess.run(
         [
             'cylc', 'install', '-O', 'bar', '-D', '[env]FOO=1',
-            '--flow-name', fixture_provide_flow['test_flow_name'],
-            '-C', str(fixture_provide_flow['srcpath'])
+            '--workflow-name', fixture_provide_flow['test_flow_name'],
+            str(fixture_provide_flow['srcpath'])
         ],
         capture_output=True,
         env=os.environ

--- a/tests/functional/test_reinstall_fileinstall.py
+++ b/tests/functional/test_reinstall_fileinstall.py
@@ -56,8 +56,8 @@ def test_install_flow(fixture_provide_flow):
     result = subprocess.run(
         [
             'cylc', 'install',
-            '--flow-name', fixture_provide_flow['test_flow_name'],
-            '-C', str(fixture_provide_flow['srcpath'])
+            '--workflow-name', fixture_provide_flow['test_flow_name'],
+            str(fixture_provide_flow['srcpath'])
         ],
         capture_output=True,
         env=os.environ

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -61,7 +61,7 @@ def fixture_provide_flow(tmp_path):
 def fixture_install_flow(fixture_provide_flow):
     srcpath, datapath, flow_name = fixture_provide_flow
     result = subprocess.run(
-        ['cylc', 'install', '--flow-name', flow_name, '-C', f'{str(srcpath)}'],
+        ['cylc', 'install', '--workflow-name', flow_name, f'{str(srcpath)}'],
         capture_output=True,
     )
     destpath = Path(get_workflow_run_dir(flow_name))

--- a/tests/test_rose_opts.py
+++ b/tests/test_rose_opts.py
@@ -62,7 +62,7 @@ def fixture_provide_flow(tmp_path_factory):
 def fixture_install_flow(fixture_provide_flow):
     srcpath, datapath, flow_name = fixture_provide_flow
     cmd = shlex.split(
-        f'cylc install --flow-name {flow_name} -C {str(srcpath)} '
+        f'cylc install --workflow-name {flow_name} {str(srcpath)} '
         '--no-run-name '  # Avoid having to keep looking a sub-dir.
         '--opt-conf-key="A" -O "B" '
         '--define "[env]FOO=42" -D "[jinja2:suite.rc]BAR=84" '


### PR DESCRIPTION
- [x] `--directory` deprecated
- [x] `--flow-name` ⇒ `--workflow-name`

This is a small change with no associated Issue: Recent changes in the CLI for `cylc install` (https://github.com/cylc/cylc-flow/pull/4823) broke a large number of tests.

They also broke Rose Stem, but this PR does not attempt to fix this - will do that in a later PR.

**It will therefore fail tests, but only rose stem tests should fail.**

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Already covered by existing tests.
- [x] No change log entry required - fixes tests.
- [x] No documentation update required.
