### PR TITLE
Jinja2 v3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 [#140](https://github.com/cylc/cylc-rose/pull/140) -
 Support integers with leading zeros (e.g `001`) to back support Rose
-configurations for use with cylc-flow>=8.0rc5 which uses Jinja2 v3 which
+configurations for use with cylc-flow>=8.0rc4 which uses Jinja2 v3 which
 no longer supports this.
 
 ## __cylc-rose-1.0.3 (<span actions:bind='release-date'>Released 2022-05-20</span>)__

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,30 @@
 # Selected Cylc-Rose Changes
 
+## __cylc-rose-1.? (<span actions:bind='release-date'>Pending</span>)__
+
+### Fixes
+
+[#140](https://github.com/cylc/cylc-rose/pull/140) -
+Support integers with leading zeros (e.g `001`) to back support Rose
+configurations for use with cylc-flow>=8.0rc5 which uses Jinja2 v3 which
+no longer supports this.
+
 ## __cylc-rose-1.0.3 (<span actions:bind='release-date'>Released 2022-05-20</span>)__
 
 ### Fixes
 
-[139](https://github.com/cylc/cylc-rose/pull/139) - Make `rose stem` command
+[#139](https://github.com/cylc/cylc-rose/pull/139) - Make `rose stem` command
 work correctly with changes made to `cylc install` in
 [cylc-flow PR #4823](https://github.com/cylc/cylc-flow/pull/4823)
 
-[130](https://github.com/cylc/cylc-rose/pull/130) - Fix bug preventing
+[#130](https://github.com/cylc/cylc-rose/pull/130) - Fix bug preventing
 ``cylc reinstall`` using Rose fileinstall.
 
-[132](https://github.com/cylc/cylc-rose/pull/132) - Fix bug preventing
+[#132](https://github.com/cylc/cylc-rose/pull/132) - Fix bug preventing
 Cylc commands (other than `install`) from accessing the content of
 `--rose-template-variable`.
 
-[133](https://github.com/cylc/cylc-rose/pull/133) - Fix bug allowing setting
+[#133](https://github.com/cylc/cylc-rose/pull/133) - Fix bug allowing setting
 multiple template variable sections.
 
 ## __cylc-rose-1.0.2 (<span actions:bind='release-date'>Released 2022-03-24</span>)__
@@ -25,7 +34,7 @@ multiple template variable sections.
 [118](https://github.com/cylc/cylc-rose/pull/118) - Fail if
 a workflow is not a Rose Suite but user provides Rose CLI options.
 
-## cylc-rose-1.0.1 (Released 2022-02-17)
+## __cylc-rose-1.0.1 (Released 2022-02-17)__
 
 First official release of Cylc-Rose.
 


### PR DESCRIPTION
> Sibling to an upcoming cylc-flow PR switching from Jinja2 v2->v3.

Jinja2v2 used to support zero-prefixed integers e.g. 01, 02, 03, ...

Jinja2v3 dropped support for this, fair enough, however, our users haven't been getting warnings for this so haven't had time to adapt.

This PR patches the Jinja2 parser we use in cylc-rose to shave off the leading zero before we pass the template variable back through to Jinja2 itself. It's not a particularly nice solution, it is intended as a stopgap to help users to migrate with the intention that we would retire it ASAP, probably with the move to Jinja2 3.1.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
- [x] Made Discourse post to raise awareness of this change - https://cylc.discourse.group/t/jinja2-upgrade-to-version-3/489
  (note post not yet public, waiting for the rc4 release first)