### PR TITLE
jinja2: fix parsing of zeros

### DIFF
--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -46,9 +46,14 @@ def _strip_leading_zeros(string):
         '1'
         >>> _strip_leading_zeros('0001')
         '1'
+        >>> _strip_leading_zeros('0')
+        '0'
+        >>> _strip_leading_zeros('000')
+        '0'
 
     """
-    return string.lstrip('0')
+    ret = string.lstrip('0')
+    return ret or '0'
 
 
 def _lexer_wrap(fcn):


### PR DESCRIPTION
Follow on from #140 which introduced back support for integers with leading zeros (e.g. `01`, `002`, etc).

Unfortunately the zero-stripping was a little over zealous so would strip the zero from the number `0` :facepalm:.