### PR TITLE
Fix.deprecation message about suiterc section

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Union
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow import LOG
-from cylc.flow.flags import cylc7_back_compat
+import cylc.flow.flags as flags
 from cylc.rose.jinja2_parser import Parser, patch_jinja2_leading_zeros
 from metomi.rose import __version__ as ROSE_VERSION
 from metomi.isodatetime.datetimeoper import DateTimeOperator
@@ -647,7 +647,7 @@ def deprecation_warnings(config_tree):
             'Cylc 8. Use `[install] symlink dirs` in global.cylc '
             'instead.')
     }
-    if not cylc7_back_compat:
+    if not flags.cylc7_back_compat:
         for string in list(config_tree.node):
             for deprecation in deprecations.keys():
                 if deprecation in string:

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -635,13 +635,14 @@ def deprecation_warnings(config_tree):
 
     deprecations = {
         'empy:suite.rc': (
-            "'empy:suite.rc' is deprecated."
+            "'rose-suite.conf[empy:suite.rc]' is deprecated."
             " Use [template variables] instead."),
         'jinja2:suite.rc': (
-            "'jinja2:suite.rc' is deprecated."
+            "'rose-suite.conf[jinja2:suite.rc]' is deprecated."
             " Use [template variables] instead."),
         'root-dir': (
-            'You have set "root-dir", which is not supported at '
+            'You have set "rose-suite.conf[root-dir]", '
+            'which is not supported at '
             'Cylc 8. Use `[install] symlink dirs` in global.cylc '
             'instead.')
     }

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Union
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow import LOG
+from cylc.flow.flags import cylc7_back_compat
 from cylc.rose.jinja2_parser import Parser, patch_jinja2_leading_zeros
 from metomi.rose import __version__ as ROSE_VERSION
 from metomi.isodatetime.datetimeoper import DateTimeOperator
@@ -646,7 +647,8 @@ def deprecation_warnings(config_tree):
             'Cylc 8. Use `[install] symlink dirs` in global.cylc '
             'instead.')
     }
-    for string in list(config_tree.node):
-        for deprecation in deprecations.keys():
-            if deprecation in string:
-                LOG.warning(deprecations[deprecation])
+    if not cylc7_back_compat:
+        for string in list(config_tree.node):
+            for deprecation in deprecations.keys():
+                if deprecation in string:
+                    LOG.warning(deprecations[deprecation])

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -27,6 +27,7 @@ from shlex import split
 from subprocess import run
 from types import SimpleNamespace
 
+import cylc
 from cylc.rose.entry_points import get_rose_vars, NotARoseSuiteException
 
 
@@ -142,17 +143,32 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
 
 
 @pytest.mark.parametrize(
+    'compat_mode',
+    [
+        pytest.param(True, id='cylc-back-compat-mode'),
+        pytest.param(False, id='no-cylc-back-compat-mode')
+    ]
+)
+@pytest.mark.parametrize(
     'rose_config', [
         '[empy:suite.rc]',
         '[jinja2:suite.rc]'
     ]
 )
-def test_warn_if_old_templating_set(rose_config, tmp_path, caplog):
+def test_warn_if_old_templating_set(
+    compat_mode, rose_config, tmp_path, caplog, monkeypatch
+):
     """Test using unsupported root-dir config raises error."""
+    monkeypatch.setattr(
+        cylc.rose.utilities, 'cylc7_back_compat', compat_mode
+    )
     (tmp_path / 'rose-suite.conf').write_text(rose_config)
     get_rose_vars(srcdir=tmp_path)
     msg = "is deprecated. Use [template variables]"
-    assert msg in caplog.records[0].message
+    if compat_mode:
+        assert not caplog.records
+    else:
+        assert msg in caplog.records[0].message
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -135,11 +135,8 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
     """Test using unsupported root-dir config raises error."""
     (tmp_path / 'rose-suite.conf').write_text(root_dir_config)
     get_rose_vars(srcdir=tmp_path)
-    assert caplog.records[0].msg == (
-        'You have set "rose-suite.conf[root-dir]", '
-        'which is not supported at Cylc 8. Use '
-        '`global.cylc[install][symlink dirs]` instead.'
-    )
+    msg = 'rose-suite.conf[root-dir]'
+    assert msg in caplog.records[0].msg
 
 
 @pytest.mark.parametrize(
@@ -160,7 +157,7 @@ def test_warn_if_old_templating_set(
 ):
     """Test using unsupported root-dir config raises error."""
     monkeypatch.setattr(
-        cylc.rose.utilities, 'cylc7_back_compat', compat_mode
+        cylc.rose.utilities.flags, 'cylc7_back_compat', compat_mode
     )
     (tmp_path / 'rose-suite.conf').write_text(rose_config)
     get_rose_vars(srcdir=tmp_path)

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -135,7 +135,8 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
     (tmp_path / 'rose-suite.conf').write_text(root_dir_config)
     get_rose_vars(srcdir=tmp_path)
     assert caplog.records[0].msg == (
-        'You have set "root-dir", which is not supported at Cylc 8. Use '
+        'You have set "rose-suite.conf[root-dir]", '
+        'which is not supported at Cylc 8. Use '
         '`[install] symlink dirs` in global.cylc instead.'
     )
 

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -138,7 +138,7 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
     assert caplog.records[0].msg == (
         'You have set "rose-suite.conf[root-dir]", '
         'which is not supported at Cylc 8. Use '
-        '`[install] symlink dirs` in global.cylc instead.'
+        '`global.cylc[install][symlink dirs]` instead.'
     )
 
 


### PR DESCRIPTION
This is a small change with no associated Issue.

## Summary
1. Warnings referring only to Cylc 8 should not appear in Cylc 7 compatibility mode.
2. Warning about `[jinja2:suite.rc]` should make it clear that they refer to `rose-suite.conf` and use the section syntax consistently.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (Change to user messages not functionality).
<!-- choose one: -->
- [x] No documentation update required.
