### PR TITLE
Warn users that  `[jinja2:flow.cylc]` will not supply template vars.

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -641,6 +641,12 @@ def deprecation_warnings(config_tree):
         'jinja2:suite.rc': (
             "'rose-suite.conf[jinja2:suite.rc]' is deprecated."
             " Use [template variables] instead."),
+        'empy:flow.cylc': (
+            "'rose-suite.conf[empy:flow.cylc]' is not used by Cylc."
+            " Use [template variables] instead."),
+        'jinja2:flow.cylc': (
+            "'rose-suite.conf[jinja2:flow.cylc]' is not used by Cylc."
+            " Use [template variables] instead."),
         'root-dir': (
             'You have set "rose-suite.conf[root-dir]", '
             'which is not supported at '
@@ -650,5 +656,5 @@ def deprecation_warnings(config_tree):
     if not flags.cylc7_back_compat:
         for string in list(config_tree.node):
             for deprecation in deprecations.keys():
-                if deprecation in string:
+                if deprecation in string.lower():
                     LOG.warning(deprecations[deprecation])

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -142,14 +142,17 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
 @pytest.mark.parametrize(
     'compat_mode',
     [
-        pytest.param(True, id='cylc-back-compat-mode'),
-        pytest.param(False, id='no-cylc-back-compat-mode')
+        pytest.param(True, id='back-compat'),
+        pytest.param(False, id='no-back-compat')
     ]
 )
 @pytest.mark.parametrize(
     'rose_config', [
-        '[empy:suite.rc]',
-        '[jinja2:suite.rc]'
+        'empy:suite.rc',
+        'jinja2:suite.rc',
+        'empy:flow.cylc',
+        'jinja2:flow.cylc',
+        'JinjA2:flOw.cylC',
     ]
 )
 def test_warn_if_old_templating_set(
@@ -159,9 +162,9 @@ def test_warn_if_old_templating_set(
     monkeypatch.setattr(
         cylc.rose.utilities.flags, 'cylc7_back_compat', compat_mode
     )
-    (tmp_path / 'rose-suite.conf').write_text(rose_config)
+    (tmp_path / 'rose-suite.conf').write_text(f'[{rose_config}]')
     get_rose_vars(srcdir=tmp_path)
-    msg = "is deprecated. Use [template variables]"
+    msg = "Use [template variables]"
     if compat_mode:
         assert not caplog.records
     else:


### PR DESCRIPTION
Added a .lower method to ensure that, as in parsec the case of the
rose section header is not considered.

This is a small change with no associated Issue.

### The issue

A test user was spotted trying to use `rose-suite.conf[jinja2:flow.cylc]`, and was surprised to get a validation failure. Items in this section are not passed to Cylc by the plugin.

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] No change log entry required (Change is improved documentation/warning of existing functionality).
- [x] No documentation update required.
