### PR TITLE
db: use the public rather than the private database

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,10 @@ Support integers with leading zeros (e.g `001`) to back support Rose
 configurations for use with cylc-flow>=8.0rc4 which uses Jinja2 v3 which
 no longer supports this.
 
+[#155](https://github.com/cylc/cylc-rose/pull/155) -
+Use the public rather than private database for platform lookups. This resolves
+a database locking issue with the `rose_prune` built-in app.
+
 ## __cylc-rose-1.0.3 (<span actions:bind='release-date'>Released 2022-05-20</span>)__
 
 ### Fixes

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -117,7 +117,7 @@ def test_process(tmp_path, srcdir, envvars, args):
         envvars = os.environ.update(envvars)
     srcdir = Path(__file__).parent / srcdir
     result = run(
-        ['cylc', 'view', '-p', '--stdout', str(srcdir)],
+        ['cylc', 'view', '-p', str(srcdir)],
         capture_output=True,
         env=envvars
     ).stdout.decode()

--- a/tests/unit/test_platform_utils.py
+++ b/tests/unit/test_platform_utils.py
@@ -33,6 +33,9 @@ from cylc.rose.platform_utils import (
 
 from cylc.flow.cfgspec.globalcfg import SPEC
 from cylc.flow.parsec.config import ParsecConfig
+from cylc.flow.pathutil import (
+    get_workflow_run_pub_db_path
+)
 
 MOCK_GLBL_CFG = (
     'cylc.flow.platforms.glbl_cfg',
@@ -105,7 +108,7 @@ def fake_flow():
     """Set up enough of an installed flow for tests in module.
 
     1. Set up an installed ``flow.cylc`` config file.
-    2. Set up a fake flow database in ``.service/db``.
+    2. Set up a fake flow database in ``log/db``.
 
     Returns:
         flow_name: Name of fake workflow.
@@ -141,8 +144,8 @@ def fake_flow():
     """)
 
     # Set up a database
-    service_dir = flow_path / '.service'
-    service_dir.mkdir(parents=True)
+    db_file = get_workflow_run_pub_db_path(flow_name)
+    Path(db_file).parent.mkdir()
     db_script = (
         b"CREATE TABLE task_jobs("
         b"cycle TEXT, name TEXT, submit_num INTEGER, platform_name TEXT);\n"
@@ -156,8 +159,8 @@ def fake_flow():
         b"    VALUES ('2', 'baz', 1, 'milk');\n"
     )
     run(
-        ['sqlite3', f'{str(service_dir / "db")}'],
-        input=db_script
+        ['sqlite3', db_file],
+        input=db_script,
     )
 
     yield flow_name, flow_path


### PR DESCRIPTION
Closes https://github.com/metomi/rose/issues/2558

* The `get_platforms_from_task_jobs` interface was using the private
  database.
* The private database is for use by the scheduler process/thread alone,
  access from other connections can result in database locked errors.

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Includes tests.
- [x] Appropriate change log entry included.
- [x] No documentation update required.
