### PR TITLE
Rose stem was not handling no arguments correctly

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ ones in. -->
 
 ### Fixes
 
+[#170](https://github.com/cylc/cylc-rose/pull/170) - Fix support for
+installing workflows using --source.
+
 [#140](https://github.com/cylc/cylc-rose/pull/140) -
 Support integers with leading zeros (e.g `001`) to back support Rose
 configurations for use with cylc-flow>=8.0rc4 which uses Jinja2 v3 which

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -485,7 +485,7 @@ def get_source_opt_from_args(opts, args):
         Cylc options with source attribute added.
     """
     if args:
-        # The arg is eqivelent to rose-stem -C at Rose 2019
+        # The arg is equivalent to rose-stem -C at Rose 2019
         path = Path(args[0])
         if not path.is_absolute():
             path = Path.cwd() / path

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -617,3 +617,30 @@ class TestProjectNotInKeywords:
         assert (b'Cannot ascertain project for source tree' in
                 project_not_in_keywords.stderr
                 )
+
+
+class TestFCMFreeRepo:
+    def test_fcm_free_repo(self, tmp_path):
+        """It installs correctly when the first source is a non-fcm repo.
+        """
+        flowname = f"cylc-rose-stem-test-{str(uuid4())[:8]}"
+
+        rose_stem_dir = (
+            tmp_path / flowname / 'rose-stem'
+        )
+        rose_stem_dir.mkdir(parents=True)
+        (rose_stem_dir / 'rose-suite.conf').write_text("ROSE_STEM_VERSION=1")
+        (rose_stem_dir / 'flow.cylc').touch()
+        run_stem = subprocess.run(
+            split(
+                f'rose stem --source=X={rose_stem_dir.parent} ',
+            ),
+            capture_output=True,
+        )
+        try:
+            assert run_stem.returncode == 0
+        except AssertionError as exc:
+            [print(i) for i in run_stem.stderr.decode().split('\n')]
+            raise exc
+        else:
+            subprocess.run(split(f'cylc clean {flowname} -y -q'))

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -23,37 +23,50 @@ from cylc.rose.stem import get_source_opt_from_args
 
 
 @pytest.mark.parametrize(
-    'args, expect',
+    'args, opts, expect',
     [
         pytest.param(
             [],
+            {'stem_sources': ['foo']},
             '',
-            id='no-path'
+            id='no-args&sources'
+        ),
+        pytest.param(
+            [],
+            None,
+            '',
+            id='no-args&no-path'
         ),
         pytest.param(
             ['/foo'],
-            '/foo',
-            id='absolute-path'
+            None,
+            None,
+            id='args&absolute-path'
         ),
         pytest.param(
             ['foo'],
-            '{tmp_path}/foo',
-            id='relative-path'
+            None,
+            None,
+            id='args&relative-path'
         ),
     ]
 )
-def test_get_source_opt_from_args(tmp_path, monkeypatch, args, expect):
+def test_get_source_opt_from_args(tmp_path, monkeypatch, args, opts, expect):
     # Basic setup
     monkeypatch.chdir(tmp_path)
-    opts = SimpleNamespace()
+    if opts:
+        opts = SimpleNamespace(**opts)
+    else:
+        opts = SimpleNamespace()
+        opts.stem_sources = []
 
     # Run function
     result = get_source_opt_from_args(opts, args)
-
-    # If an arg is given we are expecting source to be added to the options.
-    # Otherwise options should be returned unchanged.
     if expect:
-        expect = SimpleNamespace(source=expect.format(tmp_path=tmp_path))
+        expect = SimpleNamespace(
+            source=expect.format(tmp_path=tmp_path),
+            stem_sources=[expect.format(tmp_path=tmp_path)]
+        )
         assert result == expect
     else:
         assert result == opts


### PR DESCRIPTION
## Issue description

(not documented elsewhere)

The rose stem tests I translated from Rose 2019

Rose Stem 2019 did not accept _any_ arguments ([docs link](http://metomi.github.io/rose/2019.01.2/html/tutorial/rose/furthertopics/rose-stem.html#the-source-argument)). It assumed that users would provide a folder containing a rose-stem workflow either by running `rose stem` with now `--source` opts in a directory where `$PWD/rose-stem` was a valid rose-stem suite, or that the first `--source` option was such a suite. If users wanted to put the workflow elsewhere without adding it to the sources list they could use the rose `-C` argument. 

A user discovered that the conversion function was not getting the workflow config dir from the first source correctly.



## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
