### PR TITLE
Don't pass rose variables with state ! or !! to Cylc.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,14 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+## __cylc-rose-1.1.1 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#171](https://github.com/cylc/cylc-rose/pull/171) - Fix bug where Cylc Rose
+passed `rose-suite.conf` items commented with `!` or `!!` to Cylc regardless.
+
+
 ## __cylc-rose-1.1.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 
 ### Fixes

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -129,19 +129,23 @@ def get_rose_vars_from_config_node(config, config_node, environ):
     # For each of the template language sections extract items to a simple
     # dict to be returned.
     if 'env' in config_node.value:
+
         config['env'] = {
             item[0][1]: item[1].value for item in
             config_node.value['env'].walk()
+            if item[1].state == ConfigNode.STATE_NORMAL
         }
     if templating in config_node.value:
         config['template_variables'] = {
             item[0][1]: item[1].value for item in
             config_node.value[templating].walk()
+            if item[1].state == ConfigNode.STATE_NORMAL
         }
     elif 'template variables' in config_node.value:
         config['template_variables'] = {
             item[0][1]: item[1].value for item in
             config_node.value['template variables'].walk()
+            if item[1].state == ConfigNode.STATE_NORMAL
         }
 
     # Add the entire config to ROSE_SUITE_VARIABLES to allow for programatic

--- a/tests/functional/test_validate_no_rose_ignore_items.py
+++ b/tests/functional/test_validate_no_rose_ignore_items.py
@@ -1,0 +1,45 @@
+# THIS FILE IS PART OF THE ROSE-CYLC PLUGIN FOR THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Functional Test: It ignores commented items in rose-suite.conf
+
+See https://github.com/cylc/cylc-rose/pull/171
+"""
+
+from shlex import split
+from subprocess import run
+
+
+def test_cylc_validate(tmp_path):
+    """It doesn't pass commented vars to Cylc.
+    """
+    (tmp_path / 'flow.cylc').write_text("""#!jinja2
+{{ assert(UNCOMMENTED is defined, "UNCOMMENTED is not defined") }}
+{{ assert(SINGLE is not defined, "SINGLE is defined") }}
+{{ assert(DOUBLE is not defined, "DOUBLE is defined") }}
+    """)
+    (tmp_path / 'rose-suite.conf').write_text(
+        '[template variables]\n'
+        'UNCOMMENTED="bar"\n'
+        '!SINGLE="bar"\n'
+        '!!DOUBLE="baz"\n'
+    )
+    result = run(
+        split(f'cylc view --jinja2 {str(tmp_path)}'), capture_output=True)
+
+    if result.returncode == 0:
+        assert True
+    else:
+        raise Exception(result.stderr.decode())


### PR DESCRIPTION
This is a small change with no associated Issue.

It closes an otherwise undocumented bug where variables commented in a `rose-suite.conf` (with a `!` or `!!`) are passed to Cylc regardless.

<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
<!-- choose one: -->
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
