### PR TITLE
Rose Stem Fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,9 @@ a database locking issue with the `rose_prune` built-in app.
 
 ### Fixes
 
+[#172](https://github.com/cylc/cylc-rose/pull/172) - Allow getting a workflow
+name when source is not an SVN repo.
+
 [#139](https://github.com/cylc/cylc-rose/pull/139) - Make `rose stem` command
 work correctly with changes made to `cylc install` in
 [cylc-flow PR #4823](https://github.com/cylc/cylc-flow/pull/4823)

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -529,16 +529,6 @@ def main():
     # use the cylc install option parser
     parser = get_option_parser()
 
-    # Hard-set for now, but could be set based upon cylc verbosity levels?
-    parser.add_option(
-        '--verbosity', '-v', default=1,
-        help='Increase the verbosity of logging.'
-    )
-    parser.add_option(
-        '--quietness', '-q', default=0,
-        help='Decrease the verbosity of logging.'
-    )
-
     # TODO: add any rose stem specific CLI args that might exist
     # On inspection of rose/lib/python/rose/opt_parse.py it turns out that
     # opts.group is stored by the --task option.
@@ -579,6 +569,11 @@ def main():
     opts, args = parser.parse_args(sys.argv[1:])
     # sliced sys.argv to drop 'rose-stem'
     opts = get_source_opt_from_args(opts, args)
+
+    # Verbosity is set using the Cylc options which decrement and increment
+    # verbosity as part of the parser, but rose needs opts.quietness too, so
+    # hard set it.
+    opts.quietness = 0
 
     try:
         # modify the CLI options to add whatever rose stem would like to add

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -64,6 +64,7 @@ Jinja2 Variables
 
 from ansimarkup import parse as cparse
 from contextlib import suppress
+from optparse import OptionGroup
 import os
 from pathlib import Path
 import re
@@ -528,24 +529,6 @@ def main():
     # use the cylc install option parser
     parser = get_option_parser()
 
-    # TODO: add any rose stem specific CLI args that might exist
-    # On inspection of rose/lib/python/rose/opt_parse.py it turns out that
-    # opts.group is stored by the --task option.
-    parser.add_option(
-        "--task", "--group",
-        help="Specifies a source tree to include in a suite.",
-        action="append",
-        metavar="PATH/TO/FLOW",
-        default=[],
-        dest="stem_groups")
-    parser.add_option(
-        "--source",
-        help="Specifies a source tree to include in a suite.",
-        action="append",
-        metavar="PATH/TO/FLOW",
-        default=[],
-        dest="stem_sources")
-
     # Hard-set for now, but could be set based upon cylc verbosity levels?
     parser.add_option(
         '--verbosity', '-v', default=1,
@@ -555,6 +538,42 @@ def main():
         '--quietness', '-q', default=0,
         help='Decrease the verbosity of logging.'
     )
+
+    # TODO: add any rose stem specific CLI args that might exist
+    # On inspection of rose/lib/python/rose/opt_parse.py it turns out that
+    # opts.group is stored by the --task option.
+    rose_stem_options = OptionGroup(parser, 'Rose Stem Specific Options')
+    rose_stem_options.add_option(
+        "--task", "--group", "-t", "-g",
+        help=(
+            "Specify a group name to run. Additional groups can be specified"
+            "with further `--group` arguments. The suite will then convert the"
+            "groups into a series of tasks to run."
+        ),
+        action="append",
+        metavar="PATH/TO/FLOW",
+        default=[],
+        dest="stem_groups")
+    rose_stem_options.add_option(
+        "--source", '-s',
+        help=(
+            "Specify a source tree to include in a rose-stem suite. The first"
+            "source tree must be a working copy as the location of the suite"
+            "and fcm-make config files are taken from it. Further source"
+            "trees can be added with additional `--source` arguments. "
+            "The project which is associated with a given source is normally "
+            "automatically determined using FCM, however the project can "
+            "be specified by putting the project name as the first part of "
+            "this argument separated by an equals sign as in the third "
+            "example above. Defaults to `.` if not specified."
+        ),
+        action="append",
+        metavar="PATH/TO/FLOW",
+        default=[],
+        dest="stem_sources")
+
+    parser.add_option_group(rose_stem_options)
+
     parser.usage = __doc__
 
     opts, args = parser.parse_args(sys.argv[1:])

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -21,6 +21,8 @@
 Tests for cylc.rose.stem
 ========================
 
+These tests are based on the Rose 2019 tests for Rose Stem.
+
 Structure
 ---------
 
@@ -173,7 +175,10 @@ def setup_stem_repo(tmp_path_factory, monkeymodule, request):
         'suite_install_dir': suite_install_dir
     }
     # Only clean up if all went well.
-    if not request.session.testsfailed:
+    if (
+        not request.session.testsfailed
+        and Path(suite_install_dir).exists()
+    ):
         shutil.rmtree(suite_install_dir)
 
 
@@ -613,7 +618,6 @@ class TestProjectNotInKeywords:
     def test_project_not_in_keywords(self, project_not_in_keywords):
         """test for successful execution with site/user configuration
         """
-        assert project_not_in_keywords.returncode == 1
-        assert (b'Cannot ascertain project for source tree' in
-                project_not_in_keywords.stderr
-                )
+        assert project_not_in_keywords.returncode == 0
+        stderr = project_not_in_keywords.stderr.decode()
+        assert 'Cannot ascertain project for source tree' in stderr

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -27,7 +27,7 @@ from cylc.rose.stem import get_source_opt_from_args
     [
         pytest.param(
             [],
-            '',
+            None,
             id='no-path'
         ),
         pytest.param(
@@ -43,17 +43,14 @@ from cylc.rose.stem import get_source_opt_from_args
     ]
 )
 def test_get_source_opt_from_args(tmp_path, monkeypatch, args, expect):
-    # Basic setup
+    """It converts Rose 2 CLI features to options usable by Rose Stem
+    """
     monkeypatch.chdir(tmp_path)
     opts = SimpleNamespace()
 
-    # Run function
-    result = get_source_opt_from_args(opts, args)
+    result = get_source_opt_from_args(opts, args).source
 
-    # If an arg is given we are expecting source to be added to the options.
-    # Otherwise options should be returned unchanged.
-    if expect:
-        expect = SimpleNamespace(source=expect.format(tmp_path=tmp_path))
+    if expect is None:
         assert result == expect
     else:
-        assert result == opts
+        assert result == expect.format(tmp_path=str(tmp_path))


### PR DESCRIPTION
This is a small change with no associated Issue.

## Summary of issue

At Rose 2019  the command `rose stem  --source=X=$PWD` would set the variable `conf_dir` to None by default, before passing the options to the `StemRunner.process` method.

At Rose 2 I had failed to do this and as a result attempts to calculate the `conf_dir` in Rose failed because there was no `conf_dir` to reference.

n.b. In the process of translating the Rose 2019 code I renamed `conf_dir` and `source` to `source` and `stem_sources` respectively. I'm not completely happy with that decision, but I don't want to add a reversion to it to this PR.

## Additional things

- I've copied the Rose 2019 help docs for rose stem - they probably aren't perfect, but I've created https://github.com/cylc/cylc-rose/issues/176 to improve them.
- A bug with the target for installation of non-fcm workflows has been written up as #177 


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
