### PR TITLE
Bump cylc-flow dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ python_requires = >=3.7
 include_package_data = True
 install_requires =
     metomi-rose==2.0.*
-    cylc-flow==8.0.*
+    cylc-flow==8.1.*
     metomi-isodatetime
     jinja2
 


### PR DESCRIPTION
I think the reason the cylc-doc GH Actions is failing to install the libraries is the conflicting dependencies
```ini
# cylc-uiserver
cylc-flow==8.1.*
```
```ini
# cylc-rose
cylc-flow==8.0.*
```

I have updated the dependency on cylc-flow to `8.1.*` here, to match cylc-uiserver.

Strictly speaking this should be on the 1.2.0 milestone rather than 1.1.1. Perhaps we should create a 1.1.x branch like we've got in cylc-flow for the maintenance releases?

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Does not need tests 
- [x] No change log entry required (invisible to users).
- [x] No documentation update required.
