### PR TITLE
Revert "Bump cylc-flow dependency (#173)"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ python_requires = >=3.7
 include_package_data = True
 install_requires =
     metomi-rose==2.0.*
-    cylc-flow==8.1.*
+    cylc-flow==8.0.*
     metomi-isodatetime
     jinja2
 


### PR DESCRIPTION
This reverts commit 7b7ba353d98fb7c1bec2ee669a5e3d97e6279472.

Reverting to allow the last 1.1.1 PR to be merged, release 1.1.1, then merge this.

For future minor releases we should bump the version right away and create a `.x` milestone if needed, or find a way to automate that?
