### PR TITLE
Fix changelog conflict with 1.1.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,13 +5,15 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
-## __cylc-rose-1.1.1 (<span actions:bind='release-date'>Upcoming</span>)__
+## __cylc-rose-1.1.1 (<span actions:bind='release-date'>Released 2022-09-14</span>)__
 
 ### Fixes
 
 [#171](https://github.com/cylc/cylc-rose/pull/171) - Fix bug where Cylc Rose
 passed `rose-suite.conf` items commented with `!` or `!!` to Cylc regardless.
 
+[#172](https://github.com/cylc/cylc-rose/pull/172) - Allow getting a workflow
+name when source is not an SVN repo.
 
 ## __cylc-rose-1.1.0 (<span actions:bind='release-date'>Released 2022-07-28</span>)__
 


### PR DESCRIPTION
This seems to be the only way to resolve the conflict without inadvertently changing setup.cfg on master.

After this is merged, we can reopen #184 