### PR TITLE
Bump rose dependency to `2.1.*`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ packages = find_namespace:
 python_requires = >=3.7
 include_package_data = True
 install_requires =
-    metomi-rose==2.0.*
+    metomi-rose==2.1.*
     cylc-flow==8.1.*
     metomi-isodatetime
     jinja2


### PR DESCRIPTION
Because we now have different branches for metomi-rose for 2.0.x and 2.1.x (master) the dependency here (on cylc-rose master branch) has to be bumped to `2.1.*` in order for GH Actions install step to work across our different repos.

---

The alternative, seeing as there is nothing on metomi-rose master that isn't on 2.0.x (other than the `__init__.py` version number), is to roll back the `__init__.py` version number and ditch the 2.0.x branch until such a time as it is actually needed.