### PR TITLE
Allow change of templating language when reinstalling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 `actions:bind` attribute, which is used by a regex to find the text to be
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
+## __cylc-rose-1.1.2 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#192](https://github.com/cylc/cylc-rose/pull/192) - Fix bug where Cylc Rose would prevent change to template language on reinstall.
+
+
 ## __cylc-rose-1.1.1 (<span actions:bind='release-date'>Released 2022-09-14</span>)__
 
 ### Fixes

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -180,6 +180,8 @@ def record_cylc_install_options(
     # Leave now if there is nothing to do:
     if not cli_config:
         return False
+    # raise error if CLI config has multiple templating sections
+    identify_templating_section(cli_config)
 
     # Construct path objects representing our target files.
     (Path(rundir) / 'opt').mkdir(exist_ok=True)
@@ -195,6 +197,8 @@ def record_cylc_install_options(
             conf_filepath.unlink()
         else:
             oldconfig = loader.load(str(conf_filepath))
+            # Check old config for clashing template variables sections.
+            identify_templating_section(oldconfig)
             cli_config = merge_rose_cylc_suite_install_conf(
                 oldconfig, cli_config
             )
@@ -211,7 +215,6 @@ def record_cylc_install_options(
             ]
 
     cli_config.comments = [' This file records CLI Options.']
-    identify_templating_section(cli_config)
     dumper.dump(cli_config, str(conf_filepath))
 
     # Merge the opts section of the rose-suite.conf with those set by CLI:
@@ -221,7 +224,6 @@ def record_cylc_install_options(
     rose_suite_conf = add_cylc_install_to_rose_conf_node_opts(
         rose_suite_conf, cli_config
     )
-    identify_templating_section(rose_suite_conf)
     dumper(rose_suite_conf, rose_conf_filepath)
 
     return cli_config, rose_suite_conf

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -224,6 +224,8 @@ def record_cylc_install_options(
     rose_suite_conf = add_cylc_install_to_rose_conf_node_opts(
         rose_suite_conf, cli_config
     )
+    identify_templating_section(rose_suite_conf)
+
     dumper(rose_suite_conf, rose_conf_filepath)
 
     return cli_config, rose_suite_conf

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -250,38 +250,3 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
 def test_cylc_reinstall_files2(fixture_reinstall_flow2, file_, expect):
     fpath = fixture_reinstall_flow2['fixture_provide_flow']['flowpath']
     assert (fpath / file_).read_text() == expect
-
-
-def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path, request):
-    """If you re-install with a different templating engine in suite.rc
-    reinstall should fail.
-    """
-    (tmp_path / 'rose-suite.conf').write_text(
-        '[jinja2:suite.rc]\n'
-        'Primrose=\'Primula Vulgaris\'\n'
-    )
-    (tmp_path / 'flow.cylc').touch()
-    test_flow_name = f'cylc-rose-test-{str(uuid4())[:8]}'
-    install = subprocess.run(
-        [
-            'cylc', 'install', str(tmp_path), '--workflow-name',
-            test_flow_name, '--no-run-name'
-        ]
-    )
-    assert install.returncode == 0
-    (tmp_path / 'rose-suite.conf').write_text(
-        '[empy:suite.rc]\n'
-        'Primrose=\'Primula Vulgaris\'\n'
-    )
-    reinstall = subprocess.run(
-        ['cylc', 'reinstall', test_flow_name],
-        capture_output=True
-    )
-    assert reinstall.returncode != 0
-    assert (
-        'You should not define more than one templating section'
-        in reinstall.stderr.decode()
-    )
-    # Clean up run dir:
-    if not request.session.testsfailed:
-        shutil.rmtree(get_workflow_run_dir(test_flow_name))

--- a/tests/unit/test_config_tree.py
+++ b/tests/unit/test_config_tree.py
@@ -22,6 +22,7 @@ Warning:
 
 import os
 import pytest
+from pytest import param
 
 from types import SimpleNamespace
 from io import StringIO
@@ -41,7 +42,6 @@ from cylc.rose.entry_points import (
 from metomi.rose.config import ConfigLoader
 
 
-param = pytest.param
 HOST = get_host()
 
 
@@ -534,24 +534,37 @@ def test_get_cli_opts_node(opt_confs, defines, rose_template_vars, expect):
     'old, new, expect',
     [
         # An example with only opts:
-        ('opts=a b c', 'opts=c d e', '\nopts=a b c d e\n'),
+        param(
+            'opts=a b c', 'opts=c d e', '\nopts=a b c d e\n',
+            id='only opts'
+        ),
         # An example with lots of options:
-        (
+        param(
             'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree',
             'opts=B C\n[env]\nFOO=Pinhoe\n[jinja2:suite.rc]\nBAR=Broadclyst',
-            'opts=A B C\n[env]\nFOO=Pinhoe\n[jinja2:suite.rc]\nBAR=Broadclyst'
+            'opts=A B C\n[env]\nFOO=Pinhoe\n[jinja2:suite.rc]\nBAR=Broadclyst',
+            id='lots of options'
+        ),
+        # An example with updated template variables:
+        param(
+            'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Ottery',
+            'opts=B C\n[env]\nFOO=Pinhoe\n[template variables]\nBAR=Whipton',
+            'opts=A B C\n[env]\nFOO=Pinhoe\n[template variables]\nBAR=Whipton',
+            id='changed template vars'
         ),
         # An example with no old opts:
-        (
+        param(
             '',
             'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree',
-            'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree'
+            'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree',
+            id='no old options'
         ),
         # An example with no new opts:
-        (
+        param(
             'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree',
             '',
-            'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree'
+            'opts=A B\n[env]\nFOO=Whipton\n[jinja2:suite.rc]\nBAR=Heavitree',
+            id='no new opts'
         )
     ]
 )


### PR DESCRIPTION
These changes close #191 

in `record_cylc_install_options` the function `identify_templating_section` is used to check whether the user has set more than one templating section. This is done after the previous `rose-suite-cylc-install.conf` has been merged with the new one, so that if the user has changed the templating language both will be present in the merged config and the test will always fail.

## Work done
- Move checks for multiple templating sections to before old and new configs are merged
- Algorithm merging previous and current config  renames old template variables section if new install has changes it.
- Update tests for merge algorithm.
- Remove test that it's impossible to change templating languages on reinstall - it should not be.


## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Appropriate tests are included (unit and/or functional).
- [x] Appropriate change log entry included.
- [x] No documentation update required.
