### PR TITLE
Remove subprocess from tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,13 @@ from cylc.flow.scripts.validate import (
 )
 
 from cylc.flow.scripts.install import (
-    install as cylc_install,
+    install_cli as cylc_install,
     get_option_parser as install_gop
+)
+
+from cylc.flow.scripts.reinstall import (
+    reinstall_cli as cylc_reinstall,
+    get_option_parser as reinstall_gop
 )
 
 
@@ -154,6 +159,40 @@ def _cylc_install_cli(capsys, caplog):
     return _inner
 
 
+def _cylc_reinstall_cli(capsys, caplog):
+    """Access the validate CLI"""
+    def _inner(workflow_id, opts=None):
+        """Install a workflow.
+
+        Args:
+            srcpath:
+            args: Dictionary of arguments.
+        """
+        parser = reinstall_gop()
+        options = parser.get_default_values()
+        options.__dict__.update({
+            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
+            'output': None
+        })
+
+        if opts is not None:
+            options.__dict__.update(opts)
+
+        output = SimpleNamespace()
+
+        try:
+            cylc_reinstall(options, workflow_id)
+            output.ret = 0
+            output.exc = ''
+        except Exception as exc:
+            output.ret = 1
+            output.exc = exc
+        output.logging = '\n'.join([i.message for i in caplog.records])
+        output.out, output.err = capsys.readouterr()
+        return output
+    return _inner
+
+
 @pytest.fixture
 def cylc_install_cli(capsys, caplog):
     return _cylc_install_cli(capsys, caplog)
@@ -162,6 +201,16 @@ def cylc_install_cli(capsys, caplog):
 @pytest.fixture(scope='module')
 def mod_cylc_install_cli(mod_capsys, mod_caplog):
     return _cylc_install_cli(mod_capsys, mod_caplog)
+
+
+@pytest.fixture
+def cylc_reinstall_cli(capsys, caplog):
+    return _cylc_reinstall_cli(capsys, caplog)
+
+
+@pytest.fixture(scope='module')
+def mod_cylc_reinstall_cli(mod_capsys, mod_caplog):
+    return _cylc_reinstall_cli(mod_capsys, mod_caplog)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def _cylc_validate_cli(capsys, caplog):
 
 
 def _cylc_install_cli(capsys, caplog):
-    """Access the validate CLI"""
+    """Access the install CLI"""
     def _inner(srcpath, args=None):
         """Install a workflow.
 
@@ -160,7 +160,7 @@ def _cylc_install_cli(capsys, caplog):
 
 
 def _cylc_reinstall_cli(capsys, caplog):
-    """Access the validate CLI"""
+    """Access the reinstall CLI"""
     def _inner(workflow_id, opts=None):
         """Install a workflow.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,42 @@
 """
 
 import pytest
+from types import SimpleNamespace
 
 from cylc.flow import __version__ as CYLC_VERSION
+
+from cylc.flow.scripts.validate import (
+    wrapped_main as cylc_validate,
+    get_option_parser as validate_gop
+)
+
+from cylc.flow.scripts.install import (
+    install as cylc_install,
+    get_option_parser as install_gop
+)
+
+
+@pytest.fixture(scope='module')
+def mod_capsys(request):
+    from _pytest.capture import SysCapture
+    capman = request.config.pluginmanager.getplugin("capturemanager")
+    capture_fixture = pytest.CaptureFixture[str](
+        SysCapture, request, _ispytest=True)
+    capman.set_fixture(capture_fixture)
+    capture_fixture._start()
+    yield capture_fixture
+    capture_fixture.close()
+    capman.unset_fixture()
+
+
+@pytest.fixture(scope='module')
+def mod_caplog(request):
+    request.node.add_report_section = lambda *args: None
+    logging_plugin = request.config.pluginmanager.getplugin('logging-plugin')
+    for _ in logging_plugin.pytest_runtest_setup(request.node):
+        caplog = pytest.LogCaptureFixture(request.node, _ispytest=True)
+    yield caplog
+    caplog._finalize()
 
 
 @pytest.fixture(scope='package', autouse=True)
@@ -55,3 +89,86 @@ def pytest_runtest_makereport(item, call):
     _module_outcomes = getattr(item.module, '_module_outcomes', {})
     _module_outcomes[(item.nodeid, rep.when)] = rep
     item.module._module_outcomes = _module_outcomes
+
+
+def _cylc_validate_cli(capsys, caplog):
+    """Access the validate CLI"""
+    def _inner(srcpath, args=None):
+        parser = validate_gop()
+        options = parser.get_default_values()
+        options.__dict__.update({
+            'templatevars': [], 'templatevars_file': []
+        })
+
+        if args is not None:
+            options.__dict__.update(args)
+
+        output = SimpleNamespace()
+
+        try:
+            cylc_validate(parser, options, str(srcpath))
+            output.ret = 0
+            output.exc = ''
+        except Exception as exc:
+            output.ret = 1
+            output.exc = exc
+
+        output.logging = '\n'.join([i.message for i in caplog.records])
+        output.out, output.err = capsys.readouterr()
+
+        return output
+    return _inner
+
+
+def _cylc_install_cli(capsys, caplog):
+    """Access the validate CLI"""
+    def _inner(srcpath, args=None):
+        """Install a workflow.
+
+        Args:
+            srcpath:
+            args: Dictionary of arguments.
+        """
+        parser = install_gop()
+        options = parser.get_default_values()
+        options.__dict__.update({
+            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
+            'output': None
+        })
+
+        if args is not None:
+            options.__dict__.update(args)
+
+        output = SimpleNamespace()
+
+        try:
+            cylc_install(options, str(srcpath))
+            output.ret = 0
+            output.exc = ''
+        except Exception as exc:
+            output.ret = 1
+            output.exc = exc
+        output.logging = '\n'.join([i.message for i in caplog.records])
+        output.out, output.err = capsys.readouterr()
+        return output
+    return _inner
+
+
+@pytest.fixture
+def cylc_install_cli(capsys, caplog):
+    return _cylc_install_cli(capsys, caplog)
+
+
+@pytest.fixture(scope='module')
+def mod_cylc_install_cli(mod_capsys, mod_caplog):
+    return _cylc_install_cli(mod_capsys, mod_caplog)
+
+
+@pytest.fixture
+def cylc_validate_cli(capsys, caplog):
+    return _cylc_validate_cli(capsys, caplog)
+
+
+@pytest.fixture(scope='module')
+def mod_cylc_validate_cli(mod_capsys, mod_caplog):
+    return _cylc_validate_cli(mod_capsys, mod_caplog)

--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -59,11 +59,9 @@ to investigate failing tests.
 
 """
 
-import os
 import pytest
 import re
 import shutil
-import subprocess
 
 from pathlib import Path
 from uuid import uuid4

--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -135,19 +135,6 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     }
 
 
-@pytest.fixture(scope='module')
-def fixture_play_flow(fixture_install_flow):
-    """Run cylc flow in a fixture.
-    """
-    flowname = fixture_install_flow['test_flow_name']
-    flowname = f"{flowname}/runN"
-    play = subprocess.run(
-        ['cylc', 'play', flowname, '--no-detach'],
-        capture_output=True, text=True
-    )
-    return play
-
-
 def test_cylc_validate_srcdir(fixture_install_flow):
     """Sanity check that workflow validates:
     """

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -91,14 +91,6 @@ def fixture_install_flow(
     ``fixture_install_flow['result'].stderr`` may help with debugging.
     """
     monkeymodule.setenv('ROSE_SUITE_OPT_CONF_KEYS', 'b')
-    # result = subprocess.run(
-    #     [
-    #         'cylc', 'install', str(fixture_provide_flow['srcpath']), '-O', 'c',
-    #         '--workflow-name', fixture_provide_flow['test_flow_name'],
-    #     ],
-    #     capture_output=True,
-    #     env=os.environ
-    # )
     result = mod_cylc_install_cli(
         fixture_provide_flow['srcpath'], {
             'opt_conf_keys': ['c'],

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -79,7 +79,9 @@ def fixture_provide_flow(tmp_path_factory, request):
 
 
 @pytest.fixture(scope='module')
-def fixture_install_flow(fixture_provide_flow, monkeymodule):
+def fixture_install_flow(
+    fixture_provide_flow, monkeymodule, mod_cylc_install_cli
+):
     """Run ``cylc install``.
 
     By running in a fixture with modular scope we
@@ -89,29 +91,36 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     ``fixture_install_flow['result'].stderr`` may help with debugging.
     """
     monkeymodule.setenv('ROSE_SUITE_OPT_CONF_KEYS', 'b')
-    result = subprocess.run(
-        [
-            'cylc', 'install', str(fixture_provide_flow['srcpath']), '-O', 'c',
-            '--workflow-name', fixture_provide_flow['test_flow_name'],
-        ],
-        capture_output=True,
-        env=os.environ
+    # result = subprocess.run(
+    #     [
+    #         'cylc', 'install', str(fixture_provide_flow['srcpath']), '-O', 'c',
+    #         '--workflow-name', fixture_provide_flow['test_flow_name'],
+    #     ],
+    #     capture_output=True,
+    #     env=os.environ
+    # )
+    result = mod_cylc_install_cli(
+        fixture_provide_flow['srcpath'], {
+            'opt_conf_keys': ['c'],
+            'workflow_name': fixture_provide_flow['test_flow_name']
+        }
     )
+
     yield {
         'fixture_provide_flow': fixture_provide_flow,
         'result': result
     }
 
 
-def test_cylc_validate(fixture_provide_flow):
+def test_cylc_validate(fixture_provide_flow, cylc_validate_cli):
     """Sanity check that workflow validates:
     """
     srcpath = fixture_provide_flow['srcpath']
-    assert subprocess.run(['cylc', 'validate', str(srcpath)]).returncode == 0
+    assert cylc_validate_cli(str(srcpath)).ret == 0
 
 
 def test_cylc_install_run(fixture_install_flow):
-    assert fixture_install_flow['result'].returncode == 0
+    assert fixture_install_flow['result'].ret == 0
 
 
 @pytest.mark.parametrize(
@@ -254,7 +263,9 @@ def test_cylc_reinstall_files2(fixture_reinstall_flow2, file_, expect):
     assert (fpath / file_).read_text() == expect
 
 
-def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path, request):
+def test_cylc_reinstall_fail_on_clashing_template_vars(
+    tmp_path, request, mod_cylc_install_cli
+):
     """If you re-install with a different templating engine in suite.rc
     reinstall should fail.
     """
@@ -264,13 +275,14 @@ def test_cylc_reinstall_fail_on_clashing_template_vars(tmp_path, request):
     )
     (tmp_path / 'flow.cylc').touch()
     test_flow_name = f'cylc-rose-test-{str(uuid4())[:8]}'
-    install = subprocess.run(
-        [
-            'cylc', 'install', str(tmp_path), '--workflow-name',
-            test_flow_name, '--no-run-name'
-        ]
-    )
-    assert install.returncode == 0
+
+    install = mod_cylc_install_cli(
+        tmp_path,
+        {
+            'workflow_name': test_flow_name,
+            'no_run_name': True
+        })
+    assert install.ret == 0
     (tmp_path / 'rose-suite.conf').write_text(
         '[empy:suite.rc]\n'
         'Primrose=\'Primula Vulgaris\'\n'

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -27,7 +27,6 @@ At each step it checks the contents of
 - ~/cylc-run/temporary-id/opt/rose-suite-cylc-install.conf
 """
 
-import os
 import pytest
 import shutil
 import subprocess
@@ -77,7 +76,9 @@ def fixture_provide_flow(tmp_path_factory, request):
 
 
 @pytest.fixture(scope='module')
-def fixture_install_flow(fixture_provide_flow, monkeymodule):
+def fixture_install_flow(
+    fixture_provide_flow, monkeymodule, mod_cylc_install_cli
+):
     """Run ``cylc install``.
 
     By running in a fixture with modular scope we
@@ -86,14 +87,13 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
     If a test fails using ``pytest --pdb then``
     ``fixture_install_flow['result'].stderr`` may help with debugging.
     """
-    result = subprocess.run(
-        [
-            'cylc', 'install', '-O', 'bar', '-D', '[env]FOO=1',
-            '--workflow-name', fixture_provide_flow['test_flow_name'],
-            str(fixture_provide_flow['srcpath'])
-        ],
-        capture_output=True,
-        env=os.environ
+    result = mod_cylc_install_cli(
+        fixture_provide_flow['srcpath'],
+        {
+            'workflow_name': fixture_provide_flow['test_flow_name'],
+            'opt_conf_keys': ['bar'],
+            'defines': ['[env]FOO=1']
+        }
     )
     yield {
         'fixture_provide_flow': fixture_provide_flow,
@@ -102,7 +102,7 @@ def fixture_install_flow(fixture_provide_flow, monkeymodule):
 
 
 def test_cylc_install_run(fixture_install_flow):
-    assert fixture_install_flow['result'].returncode == 0
+    assert fixture_install_flow['result'].ret == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_reinstall_fileinstall.py
+++ b/tests/functional/test_reinstall_fileinstall.py
@@ -51,19 +51,13 @@ def fixture_provide_flow(tmp_path_factory, request):
         shutil.rmtree(flowpath)
 
 
-def test_install_flow(fixture_provide_flow):
+def test_install_flow(fixture_provide_flow, mod_cylc_install_cli):
     """Run ``cylc install``.
     """
-    result = subprocess.run(
-        [
-            'cylc', 'install',
-            '--workflow-name', fixture_provide_flow['test_flow_name'],
-            str(fixture_provide_flow['srcpath'])
-        ],
-        capture_output=True,
-        env=os.environ
-    )
-    assert result.returncode == 0
+    result = mod_cylc_install_cli(
+        fixture_provide_flow['srcpath'],
+        {'workflow_name': fixture_provide_flow['test_flow_name']})
+    assert result.ret == 0
 
 
 def test_reinstall_flow(fixture_provide_flow):

--- a/tests/functional/test_reinstall_fileinstall.py
+++ b/tests/functional/test_reinstall_fileinstall.py
@@ -17,10 +17,8 @@
 trouble.
 """
 
-import os
 import pytest
 import shutil
-import subprocess
 
 from pathlib import Path
 from uuid import uuid4
@@ -60,15 +58,9 @@ def test_install_flow(fixture_provide_flow, mod_cylc_install_cli):
     assert result.ret == 0
 
 
-def test_reinstall_flow(fixture_provide_flow):
+def test_reinstall_flow(fixture_provide_flow, mod_cylc_reinstall_cli):
     """Run ``cylc reinstall``.
     """
-    result = subprocess.run(
-        [
-            'cylc', 'reinstall',
-            fixture_provide_flow['test_flow_name'],
-        ],
-        capture_output=True,
-        env=os.environ
-    )
-    assert result.returncode == 0
+    result = mod_cylc_reinstall_cli(
+        fixture_provide_flow['test_flow_name'])
+    assert result.ret == 0

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -18,7 +18,6 @@
 
 import pytest
 import shutil
-import subprocess
 
 from pathlib import Path
 from uuid import uuid4

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -58,12 +58,9 @@ def fixture_provide_flow(tmp_path):
 
 
 @pytest.fixture
-def fixture_install_flow(fixture_provide_flow, request):
+def fixture_install_flow(fixture_provide_flow, request, cylc_install_cli):
     srcpath, datapath, flow_name = fixture_provide_flow
-    result = subprocess.run(
-        ['cylc', 'install', '--workflow-name', flow_name, f'{str(srcpath)}'],
-        capture_output=True,
-    )
+    result = cylc_install_cli(str(srcpath), {'workflow_name': flow_name})
     destpath = Path(get_workflow_run_dir(flow_name))
 
     yield srcpath, datapath, flow_name, result, destpath
@@ -71,18 +68,18 @@ def fixture_install_flow(fixture_provide_flow, request):
         shutil.rmtree(destpath)
 
 
-def test_rose_fileinstall_validate(fixture_provide_flow):
+def test_rose_fileinstall_validate(fixture_provide_flow, cylc_validate_cli):
     """Workflow validates:
     """
     srcpath, _, _ = fixture_provide_flow
-    assert subprocess.run(['cylc', 'validate', str(srcpath)]).returncode == 0
+    assert cylc_validate_cli(str(srcpath)).ret == 0
 
 
 def test_rose_fileinstall_run(fixture_install_flow):
     """Workflow installs:
     """
     _, _, _, result, _ = fixture_install_flow
-    assert result.returncode == 0
+    assert result.ret == 0
 
 
 def test_rose_fileinstall_subfolders(fixture_install_flow):

--- a/tests/unit/test_rose_opts.py
+++ b/tests/unit/test_rose_opts.py
@@ -18,8 +18,6 @@
 
 import pytest
 import shutil
-import shlex
-import subprocess
 
 from pathlib import Path
 from uuid import uuid4

--- a/tests/unit/test_rose_opts.py
+++ b/tests/unit/test_rose_opts.py
@@ -59,16 +59,18 @@ def fixture_provide_flow(tmp_path_factory):
 
 
 @pytest.fixture(scope='module')
-def fixture_install_flow(fixture_provide_flow, request):
+def fixture_install_flow(fixture_provide_flow, request, mod_cylc_install_cli):
     srcpath, datapath, flow_name = fixture_provide_flow
-    cmd = shlex.split(
-        f'cylc install --workflow-name {flow_name} {str(srcpath)} '
-        '--no-run-name '  # Avoid having to keep looking a sub-dir.
-        '--opt-conf-key="A" -O "B" '
-        '--define "[env]FOO=42" -D "[jinja2:suite.rc]BAR=84" '
-        '--rose-template-variable="FLAKE=99" -S "CORNETTO=120" '
+    result = mod_cylc_install_cli(
+        srcpath,
+        {
+            'workflow_name': flow_name,
+            'no_run_name': True,
+            'opt_conf_keys': ['A', 'B'],
+            'defines': ["[env]FOO=42", "[jinja2:suite.rc]BAR=84"],
+            "rose_template_vars": ['FLAKE=99', "CORNETTO=120"]
+        }
     )
-    result = subprocess.run(cmd, capture_output=True)
     destpath = Path(get_workflow_run_dir(flow_name))
 
     yield srcpath, datapath, flow_name, result, destpath
@@ -76,18 +78,18 @@ def fixture_install_flow(fixture_provide_flow, request):
         shutil.rmtree(destpath)
 
 
-def test_rose_fileinstall_validate(fixture_provide_flow):
+def test_rose_fileinstall_validate(fixture_provide_flow, cylc_validate_cli):
     """Workflow validates:
     """
     srcpath, _, _ = fixture_provide_flow
-    assert subprocess.run(['cylc', 'validate', str(srcpath)]).returncode == 0
+    cylc_validate_cli(srcpath)
 
 
 def test_rose_fileinstall_run(fixture_install_flow):
     """Workflow installs:
     """
     _, _, _, result, _ = fixture_install_flow
-    assert result.returncode == 0
+    assert result.ret == 0
 
 
 def test_rose_fileinstall_rose_conf(fixture_install_flow):


### PR DESCRIPTION
Lots of tests are reliant on subprocess to run Cylc Command line scripts. In many cases this is not now necessary - Cylc offers an API for running the same script. Some of these may not work correctly until after Cylc VIP is merged


<!-- The following requirements must be satisfied (with "[x]"). -->
<!-- Mark the PR as a Draft if all requirements are not yet satisfied. -->

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Does not need tests - this is itself a testing change - the content of the tests should not have changed.
- [x] No change log entry required - testing change only
- [x] No documentation update required.
