### PR TITLE
prepare 1.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,14 +6,16 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
-## __cylc-rose-1.1.2 (<span actions:bind='release-date'>Upcoming</span>)__
+## __cylc-rose-1.2.0 (<span actions:bind='release-date'>Upcoming</span>)__
 
 ### Fixes
 
-[#192](https://github.com/cylc/cylc-rose/pull/192) - Fix bug where Cylc Rose would prevent change to template language on reinstall.
+[#192](https://github.com/cylc/cylc-rose/pull/192) -
+Fix bug where Cylc Rose would prevent change to template language on reinstall.
 
-[#180](https://github.com/cylc/cylc-rose/pull/180) - Rose stem gets stem
-suite's basename to use as workflow name when not otherwise set.
+[#180](https://github.com/cylc/cylc-rose/pull/180) -
+Rose stem gets stem suite's basename to use as workflow name when not otherwise
+set.
 
 ## __cylc-rose-1.1.1 (<span actions:bind='release-date'>Released 2022-09-14</span>)__
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ packages = find_namespace:
 python_requires = >=3.7
 include_package_data = True
 install_requires =
-    metomi-rose==2.1.*
+    metomi-rose==2.0.*
     cylc-flow==8.1.*
     metomi-isodatetime
     jinja2


### PR DESCRIPTION
Skip the `1.1.2` release, pin to metomi-rose `2.0.*` as there is no need to release `2.1.0` due to a lack of functional changes.

See https://github.com/cylc/cylc-admin/issues/162#issuecomment-1380193104

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Does not need tests (why?).
- [x] No change log entry required (why? e.g. invisible to users).
- [x] No documentation update required.