### PR TITLE
Add tests for rose options being available in Cylc View

### DIFF
--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -194,7 +194,8 @@ def generate_params():
     cmds = {
         'list': 'cylc list',
         'graph': 'cylc graph --reference',
-        'config': 'cylc config'
+        'config': 'cylc config',
+        'view': 'cylc view -j'
     }
     cases = {
         'No Opts': ['', {}, b'mynd'],


### PR DESCRIPTION
This is a small change with no associated Issue.

It tests https://github.com/cylc/cylc-flow/pull/5367

n.b. Expected to fail tests prior to merge of https://github.com/cylc/cylc-rose/pull/208

## Requirements check-list

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to `setup.cfg`.
- [x] Is a test battery addition - no need to add changelog entry or docs
