### PR TITLE
protect against None values

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -266,7 +266,7 @@ def rose_config_tree_loader(srcdir=None, opts=None):
     # templating section is.)
     if getattr(opts, 'rose_template_vars', None):
         template_section = identify_templating_section(config_tree.node)
-        for template_var in opts.rose_template_vars:
+        for template_var in opts.rose_template_vars or []:
             redefinitions.append(f'[{template_section}]{template_var}')
         # Reload the config
         config_tree = ConfigTreeLoader().load(
@@ -355,11 +355,11 @@ def get_cli_opts_node(opts=None, srcdir=None):
     defines = []
     rose_template_vars = []
     if opts and 'opt_conf_keys' in dir(opts):
-        opt_conf_keys = opts.opt_conf_keys
+        opt_conf_keys = opts.opt_conf_keys or []
     if opts and 'defines' in dir(opts):
-        defines = opts.defines
+        defines = opts.defines or []
     if opts and 'rose_template_vars' in dir(opts):
-        rose_template_vars = opts.rose_template_vars
+        rose_template_vars = opts.rose_template_vars or []
 
     rose_orig_host = get_host()
     defines.append(f'[env]ROSE_ORIG_HOST={rose_orig_host}')


### PR DESCRIPTION
If these arguments are `None` rather than `[]` errors will occur in these places.

Stick a couple of `or []`'s in there to shore things up.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.