### PR TITLE
Fix.template vars section

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+## __cylc-rose-1.3.0 (<span actions:bind='release-date'>Awaiting Release</span>)__
+
+### Fixes
+
+[#229](https://github.com/cylc/cylc-rose/pull/229) -
+Fix bug which stops rose-stem suites using the new `[template variables]` section
+in their `rose-suite.conf` files.
+
 ## __cylc-rose-1.2.0 (<span actions:bind='release-date'>Released 2023-01-16</span>)__
 
 ### Fixes

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -617,3 +617,19 @@ def test_project_not_in_keywords(setup_stem_repo, monkeymodule, capsys):
     rose_stem(parser, opts)
 
     assert 'ProjectNotFoundException' in capsys.readouterr().err
+
+
+def test_picks_template_section(setup_stem_repo, monkeymodule, capsys):
+    """It can cope with template variables section being either
+    ``template variables`` or ``jinja2:suite.rc``.
+    """
+    monkeymodule.setattr('sys.argv', ['stem'])
+    monkeymodule.chdir(setup_stem_repo['workingcopy'])
+    (setup_stem_repo['workingcopy'] / 'rose-stem/rose-suite.conf').write_text(
+        'ROSE_STEM_VERSION=1\n'
+        '[template_variables]\n'
+    )
+    parser, opts = _get_rose_stem_opts()
+    rose_stem(parser, opts)
+    _, err = capsys.readouterr()
+    assert "[jinja2:suite.rc]' is deprecated" not in err

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -26,7 +26,6 @@ from cylc.rose.stem import (
     RoseStemVersionException,
     RoseSuiteConfNotFoundException,
     StemRunner,
-    SUITE_RC_PREFIX,
     get_source_opt_from_args
 )
 
@@ -119,7 +118,7 @@ def test__add_define_option(get_StemRunner, capsys, exisiting_defines):
     stemrunner = get_StemRunner(
         {'reporter': print}, {'defines': exisiting_defines})
     assert stemrunner._add_define_option('FOO', '"bar"') is None
-    assert f'{SUITE_RC_PREFIX}FOO="bar"' in stemrunner.opts.defines
+    assert '[template variables]FOO="bar"' in stemrunner.opts.defines
     assert 'Variable FOO set to "bar"' in capsys.readouterr().out
 
 


### PR DESCRIPTION
Does not close a separate issue;

### Issue

Reported by @james-bruten-mo: 

Rose stem assumes that the name of the templating section is `[jinja2:suite.rc]`. At Rose 2  `[template variables]` is preferred, though the older form is kept for back compatibility. If the new form is used in the config file rose stems use of the older form will cause one of cylc-roses checks on the config to fail.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] ~Doc changes~ are not needed.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
