### PR TITLE
Permitted warnings about root-dir for all versions of Cylc.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+## __cylc-rose-1.2.1 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#231](https://github.com/cylc/cylc-rose/pull/231) - Show warning about
+`root-dir` config setting in compatibility mode.
+
 ## __cylc-rose-1.2.0 (<span actions:bind='release-date'>Released 2023-01-16</span>)__
 
 ### Fixes

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,17 +6,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
-## __cylc-rose-1.3.0 (<span actions:bind='release-date'>Awaiting Release</span>)__
+## __cylc-rose-1.2.1 (<span actions:bind='release-date'>Upcoming</span>)__
 
 ### Fixes
 
 [#229](https://github.com/cylc/cylc-rose/pull/229) -
 Fix bug which stops rose-stem suites using the new `[template variables]` section
 in their `rose-suite.conf` files.
-
-## __cylc-rose-1.2.1 (<span actions:bind='release-date'>Upcoming</span>)__
-
-### Fixes
 
 [#231](https://github.com/cylc/cylc-rose/pull/231) - Show warning about
 `root-dir` config setting in compatibility mode.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,8 @@ def pytest_runtest_makereport(item, call):
 def _cylc_validate_cli(capsys, caplog):
     """Access the validate CLI"""
     def _inner(srcpath, args=None):
-        options = Options(validate_gop(), args)()
+        parser = validate_gop()
+        options = Options(parser, args)()
         output = SimpleNamespace()
 
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from types import SimpleNamespace
 
 from cylc.flow import __version__ as CYLC_VERSION
+from cylc.flow.option_parsers import Options
 
 from cylc.flow.scripts.validate import (
     _main as cylc_validate,
@@ -99,11 +100,8 @@ def pytest_runtest_makereport(item, call):
 def _cylc_validate_cli(capsys, caplog):
     """Access the validate CLI"""
     def _inner(srcpath, args=None):
-        parser = validate_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'templatevars': [], 'templatevars_file': []
-        })
+        parser = Options(validate_gop())
+        options = parser()
 
         if args is not None:
             options.__dict__.update(args)
@@ -134,13 +132,7 @@ def _cylc_install_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        parser = install_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
-            'output': None
-        })
-
+        options = Options(install_gop())()
         if args is not None:
             options.__dict__.update(args)
 
@@ -168,13 +160,7 @@ def _cylc_reinstall_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        parser = reinstall_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
-            'output': None
-        })
-
+        options = Options(reinstall_gop())()
         if opts is not None:
             options.__dict__.update(opts)
 

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -157,7 +157,7 @@ def test_warn_if_old_templating_set(
 ):
     """Test using unsupported root-dir config raises error."""
     monkeypatch.setattr(
-        cylc.rose.utilities.flags, 'cylc7_back_compat', compat_mode
+        cylc.rose.utilities, 'cylc7_back_compat', compat_mode
     )
     (tmp_path / 'rose-suite.conf').write_text(f'[{rose_config}]')
     get_rose_vars(srcdir=tmp_path)


### PR DESCRIPTION
Pull request closing an issue documented here:

### Issue

This issue (https://github.com/cylc/cylc-rose/issues/230) describes a rose suite configuration which raises warnings when cylc compatibility mode is turned off. The warning that `root-dir` is no longer valid at Cylc 8 is valid whether or not compatibility mode is turned on and should be shown in either case.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
