### PR TITLE
Import Cylc option parser Options object to set up options

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 from types import SimpleNamespace
 
 from cylc.flow import __version__ as CYLC_VERSION
+from cylc.flow.option_parsers import Options
 
 from cylc.flow.scripts.validate import (
     _main as cylc_validate,
@@ -99,11 +100,8 @@ def pytest_runtest_makereport(item, call):
 def _cylc_validate_cli(capsys, caplog):
     """Access the validate CLI"""
     def _inner(srcpath, args=None):
-        parser = validate_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'templatevars': [], 'templatevars_file': []
-        })
+        parser = Options(validate_gop())
+        options = parser()
 
         if args is not None:
             options.__dict__.update(args)
@@ -134,13 +132,7 @@ def _cylc_install_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        parser = install_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
-            'output': None
-        })
-
+        options = Options(install_gop())()
         if args is not None:
             options.__dict__.update(args)
 
@@ -168,13 +160,7 @@ def _cylc_reinstall_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        parser = reinstall_gop()
-        options = parser.get_default_values()
-        options.__dict__.update({
-            'profile_mode': None, 'templatevars': [], 'templatevars_file': [],
-            'output': None
-        })
-
+        options = Options(reinstall_gop())()
         if opts is not None:
             options.__dict__.update(opts)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,9 +132,7 @@ def _cylc_install_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        options = Options(install_gop())()
-        if args is not None:
-            options.__dict__.update(args)
+        options = Options(install_gop(), args)()
 
         output = SimpleNamespace()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,11 +100,8 @@ def pytest_runtest_makereport(item, call):
 def _cylc_validate_cli(capsys, caplog):
     """Access the validate CLI"""
     def _inner(srcpath, args=None):
-        parser = Options(validate_gop())
-        options = parser()
-
-        if args is not None:
-            options.__dict__.update(args)
+        parser = validate_gop()
+        options = Options(parser, args)()
 
         output = SimpleNamespace()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,9 +155,7 @@ def _cylc_reinstall_cli(capsys, caplog):
             srcpath:
             args: Dictionary of arguments.
         """
-        options = Options(reinstall_gop())()
-        if opts is not None:
-            options.__dict__.update(opts)
+        options = Options(reinstall_gop(), opts)()
 
         output = SimpleNamespace()
 


### PR DESCRIPTION
for running Cylc installs.

It also fixes problems caused by changes to CLI options in Cylc.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] This is a change to the test battery, which does not require tests or docs.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.


IMO this is a 1-review change.