### PR TITLE
Prevent tests creating symlinks on installation.

### DIFF
--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -177,6 +177,12 @@ def setup_stem_repo(tmp_path_factory, monkeymodule, request):
         dest = str(workingcopy / 'rose-stem')
         shutil.copy2(src, dest)
     suite_install_dir = get_workflow_run_dir(suitename)
+
+    monkeymodule.setattr(
+        'cylc.flow.pathutil.make_symlink_dir',
+        lambda *_, **__: {}
+    )
+
     yield {
         'basetemp': basetemp,
         'workingcopy': workingcopy,


### PR DESCRIPTION
Some Cylc Rose tests were creating symlinks when running `cylc_install`. This change overrides the symlinking.

Equivalent of https://github.com/cylc/cylc-flow/pull/5584

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] NO tests/changelog/docs changes required: This is a small, non-functional change to the test battery.