### PR TITLE
Add missing dependency on ansimarkup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
     metomi-rose==2.1.*
     cylc-flow==8.2.*
     metomi-isodatetime
+    ansimarkup
     jinja2
 
 [options.packages.find]


### PR DESCRIPTION
`ansimarkup` is imported since #172 but not listed as a dependency. Hasn't caused any issues because it's a dependency of cylc-flow
