### PR TITLE
Stem: Make defines contain `:suite.rc`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@ ones in. -->
 [#250](https://github.com/cylc/cylc-rose/pull/250) - Prevent project
 name being manually set to an empty string.
 
+[#248](https://github.com/cylc/cylc-rose/pull/248) - Make sure that
+rose stem sets variables in `[jinja2:suite.rc]` not `[jinja2]`.
+
 ## __cylc-rose-1.3.0 (<span actions:bind='release-date'>Released 2023-07-21</span>)__
 
 ### Fixes

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -75,6 +75,7 @@ from cylc.flow.scripts.install import (
 )
 
 from cylc.rose.entry_points import get_rose_vars
+from cylc.rose.utilities import id_templating_section
 
 import metomi.rose.config
 from metomi.rose.fs_util import FileSystemUtil
@@ -452,10 +453,10 @@ class StemRunner:
             self.opts.project.append(project)
 
             if i == 0:
-                # Get the name of the template section to be used:
                 template_type = get_rose_vars(
                     Path(url) / "rose-stem")["templating_detected"]
-                self.template_section = f'[{template_type}]'
+                self.template_section = id_templating_section(
+                    template_type, with_brackets=True)
 
             # Versions of variables with hostname prepended for working copies
             url_host = self._prepend_localhost(url)

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -21,7 +21,7 @@ import os
 from pathlib import Path
 import re
 import shlex
-from typing import TYPE_CHECKING, Any, List, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 from cylc.flow.hostuserutil import get_host
 from cylc.flow import LOG
@@ -192,13 +192,27 @@ def identify_templating_section(config_node):
             "You should not define more than one templating section. "
             f"You defined:\n\t{'; '.join(defined_sections)}"
         )
-    elif 'jinja2:suite.rc' in defined_sections:
-        templating = 'jinja2:suite.rc'
-    elif 'empy:suite.rc' in defined_sections:
-        templating = 'empy:suite.rc'
+    elif defined_sections:
+        return id_templating_section(defined_sections.pop())
     else:
+        return id_templating_section('')
+
+
+def id_templating_section(
+    section: Optional[str] = None,
+    with_brackets: bool = False
+) -> str:
+    """Return a full template section string."""
+    templating = None
+    if section and 'jinja2' in section:
+        templating = 'jinja2:suite.rc'
+    elif section and 'empy' in section:
+        templating = 'empy:suite.rc'
+
+    if not templating:
         templating = 'template variables'
 
+    templating = f'[{templating}]' if with_brackets else templating
     return templating
 
 

--- a/tests/unit/test_config_node.py
+++ b/tests/unit/test_config_node.py
@@ -32,6 +32,7 @@ from cylc.rose.utilities import (
     deprecation_warnings,
     dump_rose_log,
     identify_templating_section,
+    id_templating_section,
     MultipleTemplatingEnginesError
 )
 
@@ -250,6 +251,20 @@ def test_identify_templating_section(node_, expect, raises):
     if raises is not None:
         with pytest.raises(raises):
             identify_templating_section(node)
+
+
+@pytest.mark.parametrize(
+    'input_, expect',
+    (
+        ([None], 'template variables'),
+        (['jinja2'], 'jinja2:suite.rc'),
+        (['jinja2:suite.rc'], 'jinja2:suite.rc'),
+        ([None, True], '[template variables]'),
+        (['jinja2', True], '[jinja2:suite.rc]'),
+    )
+)
+def test_id_templating_section(input_, expect):
+    assert id_templating_section(*input_) == expect
 
 
 @pytest.fixture

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -23,11 +23,12 @@ from types import SimpleNamespace
 from typing import Any, Tuple
 
 from cylc.rose.stem import (
+    _get_rose_stem_opts,
     ProjectNotFoundException,
     RoseStemVersionException,
     RoseSuiteConfNotFoundException,
     StemRunner,
-    get_source_opt_from_args
+    get_source_opt_from_args,
 )
 
 from metomi.rose.reporter import Reporter
@@ -337,3 +338,39 @@ def test_ascertain_project_if_name_supplied(
             ProjectNotFoundException, match='is not a working copy'
         ):
             stemrunner._ascertain_project(item)
+
+
+@pytest.mark.parametrize(
+    'language, expect',
+    (
+        ('empy', '[empy:suite.rc]'),
+        ('jinja2', '[jinja2:suite.rc]'),
+        ('template variables', '[template variables]'),
+    )
+)
+def test_process_template_engine_set_correctly(monkeypatch, language, expect):
+    """Defines are correctly assigned a [<template language>:suite.rc]
+    section.
+
+    https://github.com/cylc/cylc-rose/issues/246
+    """
+    # Mimic expected result from get_rose_vars method:
+    monkeypatch.setattr(
+        'cylc.rose.stem.get_rose_vars',
+        lambda _: {'templating_detected': language}
+    )
+    monkeypatch.setattr(
+        'sys.argv',
+        ['foo', 'bar']
+    )
+
+    # We are not interested in these checks, just in the defines
+    # created by the process method.
+    stemrunner = StemRunner(_get_rose_stem_opts()[1])
+    stemrunner._ascertain_project = lambda _: ['', '', '', '', '']
+    stemrunner._this_suite = lambda: '.'
+    stemrunner._check_suite_version = lambda _: '1'
+    stemrunner.process()
+
+    for define in stemrunner.opts.defines:
+        assert define.startswith(expect)


### PR DESCRIPTION
Closes #246 

Ensure that a `:suite.rc` is added to the template language when creating defines.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] This is a bug fix but there are no features on master requiring a minor release?
