### PR TITLE
Fix.rose stem name is empty string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+## __cylc-rose-1.3.1 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Fixes
+
+[#250](https://github.com/cylc/cylc-rose/pull/250) - Prevent project
+name being manually set to an empty string.
+
 ## __cylc-rose-1.3.0 (<span actions:bind='release-date'>Released 2023-07-21</span>)__
 
 ### Fixes

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -340,7 +340,7 @@ class StemRunner:
         if re.search(r'^\.', item):
             item = os.path.abspath(os.path.join(os.getcwd(), item))
 
-        if project is not None:
+        if project:
             print(f"[WARN] Forcing project for '{item}' to be '{project}'")
             return project, item, item, '', ''
 

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -316,7 +316,7 @@ def test__deduce_mirror():
 )
 def test_ascertain_project_if_name_supplied(
     get_StemRunner: Fixture,
-    capsys: Fixture,
+    capsys: pytest.CaptureFixture,
     item: str,
     expect: Tuple[str],
     stdout: str,

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -20,6 +20,7 @@ import cylc.rose
 import pytest
 from pytest import param
 from types import SimpleNamespace
+from typing import Any, Tuple
 
 from cylc.rose.stem import (
     ProjectNotFoundException,
@@ -32,6 +33,9 @@ from cylc.rose.stem import (
 from metomi.rose.reporter import Reporter
 from metomi.rose.popen import RosePopener
 from metomi.rose.fs_util import FileSystemUtil
+
+
+Fixture = Any
 
 
 class MockPopen:
@@ -291,3 +295,45 @@ def test__deduce_mirror():
     }
     project = 'someproject'
     StemRunner._deduce_mirror(source_dict, project)
+
+
+@pytest.mark.parametrize(
+    'item, expect, stdout',
+    (
+        (
+            # Normally formed project=url
+            'foo=bar',
+            ('foo', 'bar'),
+            "Forcing project for 'bar' to be 'foo'",
+        ),
+        (
+            # Malformed project=url
+            '=foo',
+            ('', 'foo'),
+            None,
+        ),
+    )
+)
+def test_ascertain_project_if_name_supplied(
+    get_StemRunner: Fixture,
+    capsys: Fixture,
+    item: str,
+    expect: Tuple[str],
+    stdout: str,
+) -> None:
+    """Method gives sensible results for different CLI input.
+
+    Written because `-s=foo` leads to "item" including a leading = sign.
+    This led to project name being set to '', and skipping the FCM
+    calling logic, which the user might expect.
+    """
+    stemrunner = get_StemRunner({})
+    if stdout:
+        results = stemrunner._ascertain_project(item)
+        assert results[:2] == expect
+        assert stdout in capsys.readouterr().out
+    else:
+        with pytest.raises(
+            ProjectNotFoundException, match='is not a working copy'
+        ):
+            stemrunner._ascertain_project(item)


### PR DESCRIPTION
Issue documented in code and PR.

Before `-s=name` would lead to project name being manually set to '' rather than using FCM to setup a project name. This is a correct from the point of view of optparse, but might seem surprising to users.

@dpmatthews  tagged as product owner/understand why the change.
@MetRonnie  as code review - IMO it's so trivial we shouldn't spend much time on it.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
