### PR TITLE
make RoseStemVersionException print the correct missing variable

### DIFF
--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -145,15 +145,17 @@ class ProjectNotFoundException(CylcError):
     __str__ = __repr__
 
 
-class RoseStemVersionException(Exception):
+class RoseStemVersionException(CylcError):
 
     """Exception class when running the wrong rose-stem version."""
 
     def __init__(self, version):
+
         Exception.__init__(self, version)
         if version is None:
             self.suite_version = (
-                "does not have ROSE_VERSION set in the rose-suite.conf"
+                "does not have ROSE_STEM_VERSION set in the "
+                "rose-suite.conf"
             )
         else:
             self.suite_version = "at version %s" % (version)
@@ -165,7 +167,7 @@ class RoseStemVersionException(Exception):
     __str__ = __repr__
 
 
-class RoseSuiteConfNotFoundException(Exception):
+class RoseSuiteConfNotFoundException(CylcError):
 
     """Exception class when unable to find rose-suite.conf."""
 

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -570,7 +570,7 @@ class TestWithConfig2:
             assert expected in with_config2['jobout_content']
 
 
-def test_incompatible_versions(setup_stem_repo, monkeymodule):
+def test_incompatible_versions(setup_stem_repo, monkeymodule, caplog, capsys):
     """It fails if trying to install an incompatible version.
     """
     # Copy suite into working copy.
@@ -587,7 +587,8 @@ def test_incompatible_versions(setup_stem_repo, monkeymodule):
             str(setup_stem_repo['workingcopy']),
             "fcm:foo.x_tr@head",
         ],
-        'workflow_name': str(setup_stem_repo['suitename'])
+        'workflow_name': str(setup_stem_repo['suitename']),
+        'verbosity': 2,
     }
 
     monkeymodule.setattr('sys.argv', ['stem'])

--- a/tests/unit/test_rose_stem_units.py
+++ b/tests/unit/test_rose_stem_units.py
@@ -277,7 +277,7 @@ def test__check_suite_version_incompatible(get_StemRunner, tmp_path):
     stemrunner = get_StemRunner(
         {}, {'stem_sources': [], 'workflow_conf_dir': str(tmp_path)})
     with pytest.raises(
-        RoseStemVersionException, match='ROSE_VERSION'
+        RoseStemVersionException, match='ROSE_STEM_VERSION'
     ):
         stemrunner._check_suite_version(str(tmp_path / 'rose-suite.conf'))
 


### PR DESCRIPTION
Fixes a small bug in an error printout:

How to reproduce:
```console
mkdir -p "${HOME}/example/rose-stem"
touch "${HOME}/example/rose-stem/flow.cylc"
touch "${HOME}/example/rose-stem/rose-suite.conf"

rose stem \
    --source=foo="${HOME}/example"\
    --workflow-name=$(uuidgen)
```

Will return an error, but at the moment the error is:
```
RoseStemVersionException: Running rose-stem version 1 but suite is does not have ROSE_VERSION set in the rose-suite.conf
```
But this is wrong and unhelpful: The variable should be ROSE_STEM_VERSION.

Additionally I've made `RoseStemVersionException` inherit `CylcError` so that we can suppress the traceback, unless in debug mode.



**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] ~Tests are included~ Any test of this change would either be overkill, or trivial.
- [x] ~`CHANGES.md` entry included~ This is effectively an internal documentation change.
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) ~ This is related to documentation changes but does not itself require them.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
