### PR TITLE
Suggested change to warning text re integers starting with a zero

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ below.
  - Mel Hall
  - Bruno Kinoshita
  - Hilary Oliver
+ - Jonny Williams
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -161,10 +161,10 @@ def patch_jinja2_leading_zeros():
     if jinja2.lexer.Lexer.wrap._instances:
         num_examples = 5
         LOG.warning(
-            'Support for integers with leading zeros (including 
+            'Support for integers with leading zeros (including'
             ' lists of integers) was dropped in Jinja2 v3.'
             ' Rose will extend support until a future version.'
-            '\nPlease amend your Rose configuration files,
+            '\nPlease amend your Rose configuration files,'
             ' which currently contain:'
             '\n * '
             + (

--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -161,10 +161,11 @@ def patch_jinja2_leading_zeros():
     if jinja2.lexer.Lexer.wrap._instances:
         num_examples = 5
         LOG.warning(
-            'Support for integers with leading zeros was dropped'
-            ' in Jinja2 v3.'
+            'Support for integers with leading zeros (including 
+            ' lists of integers) was dropped in Jinja2 v3.'
             ' Rose will extend support until a future version.'
-            '\nPlease amend your Rose configuration files e.g:'
+            '\nPlease amend your Rose configuration files,
+            ' which currently contain:'
             '\n * '
             + (
                 '\n * '.join(


### PR DESCRIPTION
Suggested change to warning text when integers with leading zeros are encountered. 

This PR addresses issue #254 

Tests not needed because only warning text is changed.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
