### PR TITLE
fix lint tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,14 +37,7 @@ jobs:
       - name: Install cylc-rose
         # need editable install for coverage
         run: |
-          pip install -e .[all]
-
-      - name: Style
-        run: |
-          flake8
-
-      - name: Mypy
-        run: mypy
+          pip install -e .[tests]
 
       - name: Checkout FCM
         uses: actions/checkout@v4
@@ -100,3 +93,36 @@ jobs:
         with:
           name: '${{ github.workflow }} py-${{ matrix.python-version }}'
           fail_ci_if_error: false
+
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3
+
+      - name: install libs
+        uses: cylc/release-actions/install-cylc-components@v1
+        with:
+          cylc_flow: true
+          cylc_flow_opts: ''
+          metomi_rose: true
+          metomi_rose_opts: ''
+
+      - name: Install cylc-rose
+        # need editable install for coverage
+        run: |
+          pip install -e .[lint]
+
+      - name: Style
+        run: |
+          flake8
+
+      - name: Mypy
+        run: mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ tests =
 lint =
     flake8
     # negociate incompatibility with flake8 4.0 and python 3.7
-    flake8<4.0.0; python_version == "3.7"
+    flake8<4.0.0; python_version >= "3.7.0", < "3.8.0"
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,13 @@ include = cylc*
 [options.extras_require]
 tests =
     coverage>=5.0.0
+    pytest
+    pytest-cov
+    pytest-xdist>=2
+lint =
     flake8
+    # negociate incompatibility with flake8 4.0 and python 3.7
+    flake8<4.0.0; python_version == "3.7"
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0
@@ -77,11 +83,9 @@ tests =
     flake8-simplify>=0.15.1
     flake8-type-checking; python_version > "3.7"
     mypy>=0.910
-    pytest
-    pytest-cov
-    pytest-xdist>=2
 all =
     %(tests)s
+    %(lint)s
 
 [options.entry_points]
 cylc.pre_configure =

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ tests =
 lint =
     flake8
     # negociate incompatibility with flake8 4.0 and python 3.7
-    flake8<4.0.0; python_version >= "3.7.0", < "3.8.0"
+    flake8<4.0.0; python_version == "3.7.*"
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
     flake8-builtins>=1.5.0


### PR DESCRIPTION
CI has started failing, looks like flake8 v4 has an incompatible dependency at Python 3.7.

**Check List**

- [ ] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [ ] Contains logically grouped changes (else tidy your branch by rebase).
- [ ] Does not contain off-topic changes (use other PRs for other changes).
- [ ] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [ ] Tests are included (or explain why tests are not needed).
- [ ] `CHANGES.md` entry included if this is a change that can affect users
- [ ] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [ ] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
