### PR TITLE
Exit immediately if no rose suite.conf

### DIFF
--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -34,6 +34,10 @@ if TYPE_CHECKING:
 
 def pre_configure(srcdir: Path, opts: 'Values') -> dict:
     """Run before the Cylc configuration is read."""
+    if not rose_config_exists(srcdir):
+        # nothing to do here
+        return {}
+
     # load the Rose config
     config_tree = load_rose_config(Path(srcdir), opts=opts)
 
@@ -53,6 +57,7 @@ def post_install(srcdir: Path, rundir: str, opts: 'Values') -> bool:
     if not rose_config_exists(srcdir):
         # nothing to do here
         return False
+
     _rundir: Path = Path(rundir)
 
     # transfer the rose-suite.conf file


### PR DESCRIPTION
Make pre-configure act like post install.

Because pre-configure uses Cylc global config in the process of getting `ROSE_ORIG_HOST` it creates an instance of the global config object with the default items if it is called before the global config is otherwise instantiated, such as when loading and parsing a global config file.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] ~Tests are included~ Change in code covered by existing tests.
- [x] ~`CHANGES.md` entry included if this is a change that can affect users~ Don't want to advertise that this _was_ possible before.
- [x] ~[Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.~
- [x] ~If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.~
