### PR TITLE
Repopulate cached GlobalConfig object if CYLC_SYMLINKS exported to env.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+
+## __cylc-rose-1.4.0 (<span actions:bind='release-date'>Upcoming</span>)__
+
+### Features
+
+[#269](https://github.com/cylc/cylc-rose/pull/269) - Allow environment variables
+set in ``rose-suite.conf`` to be used when parsing ``global.cylc``.
+
 ## __cylc-rose-1.3.1 (<span actions:bind='release-date'>Released 2023-10-24</span>)__
 
 ### Fixes

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -70,11 +70,37 @@ The following sections are permitted in the ``rose-suite.conf`` files:
    for ease of porting Cylc 7 workflows.
 
 
+The ``global.cylc`` file
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Cylc Rose Plugin forces the reloading of the ``global.cylc`` file
+to allow environment variables set by Rose to change the global configuration.
+
+For example you could use ``CYLC_SYMLINKS`` as a variable to control
+the behaviour of ``cylc install``:
+
+   .. code-block:: cylc
+
+      #!jinja2
+      # part of a global.cylc file
+      [install]
+         [[symlink dirs]]
+            [[[hpc]]]
+      {% if environ["CYLC_SYMLINKS"] | default("x") == "A" %}
+               run = $LOCATION_A
+      {% elif environ["CYLC_SYMLINKS"] | default("x") == "B" %}
+               run = $LOCATION_B
+      {% else %}
+               run = $LOCATION_C
+      {% endif %}
+
+
+
 Special Variables
 -----------------
 
 The Cylc Rose plugin provides two environment/template variables
-to the Cylc scheduler:
+to the Cylc scheduler.
 
 ``ROSE_ORIG_HOST``
    Cylc commands (such as ``cylc install``, ``cylc validate`` and
@@ -110,6 +136,7 @@ to the Cylc scheduler:
 
       ``CYLC_VERSION`` will be removed from your configuration by the
       Cylc-Rose plugin, as it is now set by Cylc.
+
 
 Additional CLI options
 ----------------------

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 from cylc.flow import LOG
 from cylc.flow.exceptions import CylcError
 from cylc.flow.flags import cylc7_back_compat
+from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.hostuserutil import get_host
 from metomi.isodatetime.datetimeoper import DateTimeOperator
 from metomi.rose import __version__ as ROSE_VERSION
@@ -868,6 +869,13 @@ def export_environment(environment: Dict[str, str]) -> None:
     # Export environment vars
     for key, val in environment.items():
         os.environ[key] = val
+
+    # If env vars have been set we want to force reload
+    # the global config so that the value of this vars
+    # can be used by Jinja2 in the global config.
+    # https://github.com/cylc/cylc-rose/issues/237
+    if environment:
+        glbl_cfg().load()
 
 
 def record_cylc_install_options(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,12 +30,12 @@ import pytest
 
 
 @pytest.fixture()
-def generate_workflow_name():
+def workflow_name():
     return 'cylc-rose-test-' + str(uuid4())[:8]
 
 
 @pytest.fixture(scope='module')
-def mod_generate_workflow_name():
+def mod_workflow_name():
     return 'cylc-rose-test-' + str(uuid4())[:8]
 
 
@@ -120,7 +120,7 @@ def _cylc_validate_cli(capsys, caplog):
     return _inner
 
 
-def _cylc_install_cli(capsys, caplog, generate_workflow_name):
+def _cylc_install_cli(capsys, caplog, workflow_name):
     """Access the install CLI"""
     def _inner(srcpath, args=None):
         """Install a workflow.
@@ -132,7 +132,7 @@ def _cylc_install_cli(capsys, caplog, generate_workflow_name):
         options = Options(install_gop(), args)()
         output = SimpleNamespace()
         if not options.workflow_name:
-            options.workflow_name = generate_workflow_name
+            options.workflow_name = workflow_name
         if not args or args and not args.get('no_run_name', ''):
             options.no_run_name = True
 
@@ -176,14 +176,14 @@ def _cylc_reinstall_cli(capsys, caplog):
 
 
 @pytest.fixture
-def cylc_install_cli(capsys, caplog, generate_workflow_name):
-    return _cylc_install_cli(capsys, caplog, generate_workflow_name)
+def cylc_install_cli(capsys, caplog, workflow_name):
+    return _cylc_install_cli(capsys, caplog, workflow_name)
 
 
 @pytest.fixture(scope='module')
-def mod_cylc_install_cli(mod_capsys, mod_caplog, mod_generate_workflow_name):
+def mod_cylc_install_cli(mod_capsys, mod_caplog, mod_workflow_name):
     return _cylc_install_cli(
-        mod_capsys, mod_caplog, mod_generate_workflow_name)
+        mod_capsys, mod_caplog, mod_workflow_name)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,13 @@ from cylc.flow.scripts.validate import get_option_parser as validate_gop
 import pytest
 
 
-@pytest.fixture
+@pytest.fixture()
 def generate_workflow_name():
+    return 'cylc-rose-test-' + str(uuid4())[:8]
+
+
+@pytest.fixture(scope='module')
+def mod_generate_workflow_name():
     return 'cylc-rose-test-' + str(uuid4())[:8]
 
 
@@ -176,8 +181,9 @@ def cylc_install_cli(capsys, caplog, generate_workflow_name):
 
 
 @pytest.fixture(scope='module')
-def mod_cylc_install_cli(mod_capsys, mod_caplog, generate_workflow_name):
-    return _cylc_install_cli(mod_capsys, mod_caplog, generate_workflow_name)
+def mod_cylc_install_cli(mod_capsys, mod_caplog, mod_generate_workflow_name):
+    return _cylc_install_cli(
+        mod_capsys, mod_caplog, mod_generate_workflow_name)
 
 
 @pytest.fixture

--- a/tests/functional/test_ROSE_ORIG_HOST.py
+++ b/tests/functional/test_ROSE_ORIG_HOST.py
@@ -119,7 +119,7 @@ def fixture_install_flow(
     )
     install_conf_path = (
         fixture_provide_flow['flowpath'] /
-        'runN/opt/rose-suite-cylc-install.conf'
+        'opt/rose-suite-cylc-install.conf'
     )
     text = install_conf_path.read_text()
     text = re.sub('ROSE_ORIG_HOST=.*', 'ROSE_ORIG_HOST=foo', text)
@@ -142,7 +142,7 @@ def test_cylc_validate_srcdir(fixture_install_flow, mod_cylc_validate_cli):
 def test_cylc_validate_rundir(fixture_install_flow, mod_cylc_validate_cli):
     """Sanity check that workflow validates:
     """
-    flowpath = fixture_install_flow['flowpath'] / 'runN'
+    flowpath = fixture_install_flow['flowpath']
     result = mod_cylc_validate_cli(flowpath)
     assert 'ROSE_ORIG_HOST (env) is:' in result.logging
 

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -118,14 +118,14 @@ def test_cylc_install_run(fixture_install_flow):
     'file_, expect',
     [
         (
-            'run1/rose-suite.conf', (
+            'rose-suite.conf', (
                 '# Config Options \'b c (cylc-install)\' from CLI appended to'
                 ' options already in `rose-suite.conf`.\n'
                 'opts=a b c (cylc-install)\n'
             )
         ),
         (
-            'run1/opt/rose-suite-cylc-install.conf', (
+            'opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c\n'
                 f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
@@ -172,14 +172,14 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
     'file_, expect',
     [
         (
-            'run1/rose-suite.conf', (
+            'rose-suite.conf', (
                 '# Config Options \'b c d (cylc-install)\' from CLI appended '
                 'to options already in `rose-suite.conf`.\n'
                 'opts=a b c d (cylc-install)\n'
             )
         ),
         (
-            'run1/opt/rose-suite-cylc-install.conf', (
+            'opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
                 f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'
@@ -230,14 +230,14 @@ def test_cylc_reinstall_run2(fixture_reinstall_flow2):
     'file_, expect',
     [
         (
-            'run1/rose-suite.conf', (
+            'rose-suite.conf', (
                 '# Config Options \'b c d (cylc-install)\' from CLI appended '
                 'to options already in `rose-suite.conf`.\n'
                 'opts=z b c d (cylc-install)\n'
             )
         ),
         (
-            'run1/opt/rose-suite-cylc-install.conf', (
+            'opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=b c d\n'
                 f'\n[env]\n#{ROHIOS}\nROSE_ORIG_HOST={HOST}\n'

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -109,7 +109,7 @@ def test_cylc_install_run(fixture_install_flow):
     'file_, expect',
     [
         (
-            'run1/opt/rose-suite-cylc-install.conf', (
+            'opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=bar\n\n'
                 '[env]\n'
@@ -163,7 +163,7 @@ def test_cylc_reinstall_run(fixture_reinstall_flow):
     'file_, expect',
     [
         (
-            'run1/opt/rose-suite-cylc-install.conf', (
+            'opt/rose-suite-cylc-install.conf', (
                 '# This file records CLI Options.\n\n'
                 '!opts=baz\n\n'
                 '[env]\n'

--- a/tests/functional/test_rose_fileinstall.py
+++ b/tests/functional/test_rose_fileinstall.py
@@ -63,7 +63,7 @@ def fixture_install_flow(fixture_provide_flow, request, cylc_install_cli):
 
     yield srcpath, datapath, flow_name, result, destpath
     if not request.session.testsfailed:
-        shutil.rmtree(destpath)
+        shutil.rmtree(destpath, ignore_errors=True)
 
 
 def test_rose_fileinstall_validate(fixture_provide_flow, cylc_validate_cli):
@@ -84,7 +84,7 @@ def test_rose_fileinstall_subfolders(fixture_install_flow):
     """File installed into a sub directory:
     """
     _, datapath, _, _, destpath = fixture_install_flow
-    assert ((destpath / 'runN/lib/python/lion.py').read_text() ==
+    assert ((destpath / 'lib/python/lion.py').read_text() ==
             (datapath / 'lion.py').read_text())
 
 
@@ -92,7 +92,7 @@ def test_rose_fileinstall_concatenation(fixture_install_flow):
     """Multiple files concatenated on install(source contained wildcard):
     """
     _, datapath, _, _, destpath = fixture_install_flow
-    assert ((destpath / 'runN/data').read_text() ==
+    assert ((destpath / 'data').read_text() ==
             ((datapath / 'randoms1.data').read_text() +
             (datapath / 'randoms3.data').read_text()
              ))

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -36,3 +36,84 @@ def test_basic(tmp_path):
     assert Path(tmp_path / 'src/rose-suite.conf').read_text() == (
         Path(tmp_path / 'dest/rose-suite.conf').read_text()
     )
+
+
+def test_CYLC_SYMLINKS_validate(monkeypatch, tmp_path, cylc_validate_cli):
+    """We reload the global config after exporting env variables."""
+    # Setup global config:
+    global_conf = """#!jinja2
+        {% from "cylc.flow" import LOG %}
+        {% set cylc_symlinks = environ.get('CYLC_SYMLINKS', None) %}
+        {% do LOG.critical(cylc_symlinks) %}
+    """
+    conf_path = tmp_path / 'conf'
+    conf_path.mkdir()
+    monkeypatch.setenv('CYLC_CONF_PATH', conf_path)
+
+    # Setup workflow config:
+    (conf_path / 'global.cylc').write_text(global_conf)
+    (tmp_path / 'rose-suite.conf').write_text(
+        '[env]\nCYLC_SYMLINKS="Foo"\n')
+    (tmp_path / 'flow.cylc').write_text("""
+        [scheduling]
+            initial cycle point = now
+            [[graph]]
+                R1 = x
+        [runtime]
+            [[x]]
+    """)
+
+    # Validate the config:
+    output = cylc_validate_cli(tmp_path)
+    assert output.ret == 0
+
+    # CYLC_SYMLINKS == None the first time the global.cylc
+    # is loaded and "Foo" the second time.
+    assert output.logging == 'None\n"Foo"'
+
+
+def test_CYLC_SYMLINKS_install(monkeypatch, tmp_path, cylc_install_cli):
+    """We reload the global config after exporting env variables."""
+    # Setup global config:
+    global_conf = (
+        '#!jinja2\n'
+        '[install]\n'
+        '    [[symlink dirs]]\n'
+        '        [[[localhost]]]\n'
+        '{% set cylc_symlinks = environ.get(\'CYLC_SYMLINKS\', None) %}\n'
+        '{% if cylc_symlinks == "foo" %}\n'
+        f'log = {str(tmp_path)}/foo\n'
+        '{% else %}\n'
+        f'log = {str(tmp_path)}/bar\n'
+        '{% endif %}\n'
+    )
+    glbl_conf_path = tmp_path / 'conf'
+    glbl_conf_path.mkdir()
+    (glbl_conf_path / 'global.cylc').write_text(global_conf)
+    monkeypatch.setenv('CYLC_CONF_PATH', glbl_conf_path)
+
+    # Setup workflow config:
+    (tmp_path / 'rose-suite.conf').write_text(
+        '[env]\nCYLC_SYMLINKS=foo\n')
+    (tmp_path / 'flow.cylc').write_text("""
+        [scheduling]
+            initial cycle point = now
+            [[graph]]
+                R1 = x
+        [runtime]
+            [[x]]
+    """)
+
+    # Install the config:
+    output = cylc_install_cli(tmp_path)
+    import sys
+    for i in output.logging.split('\n'):
+        print(i, file=sys.stderr)
+    assert output.ret == 0
+
+    # Assert symlink created back to test_path/foo:
+    expected_msg = (
+        f'Symlink created: {output.run_dir}/log -> '
+        f'{tmp_path}/foo/cylc-run/{output.id}/log'
+    )
+    assert expected_msg in output.logging.split('\n')[0]

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -69,7 +69,7 @@ def test_CYLC_SYMLINKS_validate(monkeypatch, tmp_path, cylc_validate_cli):
 
     # CYLC_SYMLINKS == None the first time the global.cylc
     # is loaded and "Foo" the second time.
-    assert output.logging == 'None\n"Foo"'
+    assert output.logging == '"Foo"'
 
 
 def test_CYLC_SYMLINKS_install(monkeypatch, tmp_path, cylc_install_cli):

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -72,7 +72,7 @@ def test_global_config_environment_validate(monkeypatch, tmp_path, cylc_validate
 
     # CYLC_SYMLINKS == None the first time the global.cylc
     # is loaded and "Foo" the second time.
-    assert output.logging == '"Foo"'
+    assert output.logging.split('\n')[-1] == '"Foo"'
 
 
 def test_global_config_environment_validate2(

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -38,8 +38,11 @@ def test_basic(tmp_path):
     )
 
 
-def test_CYLC_SYMLINKS_validate(monkeypatch, tmp_path, cylc_validate_cli):
-    """We reload the global config after exporting env variables."""
+def test_global_config_environment_validate(monkeypatch, tmp_path, cylc_validate_cli):
+    """It should reload the global config after exporting env variables.
+
+    See: https://github.com/cylc/cylc-rose/issues/237
+    """
     # Setup global config:
     global_conf = """#!jinja2
         {% from "cylc.flow" import LOG %}
@@ -72,8 +75,13 @@ def test_CYLC_SYMLINKS_validate(monkeypatch, tmp_path, cylc_validate_cli):
     assert output.logging == '"Foo"'
 
 
-def test_CYLC_SYMLINKS_install(monkeypatch, tmp_path, cylc_install_cli):
-    """We reload the global config after exporting env variables."""
+def test_global_config_environment_validate2(
+    monkeypatch, tmp_path, cylc_install_cli
+):
+    """It should reload the global config after exporting env variables.
+
+    See: https://github.com/cylc/cylc-rose/issues/237
+    """
     # Setup global config:
     global_conf = (
         '#!jinja2\n'

--- a/tests/functional/test_utils.py
+++ b/tests/functional/test_utils.py
@@ -38,7 +38,9 @@ def test_basic(tmp_path):
     )
 
 
-def test_global_config_environment_validate(monkeypatch, tmp_path, cylc_validate_cli):
+def test_global_config_environment_validate(
+    monkeypatch, tmp_path, cylc_validate_cli
+):
     """It should reload the global config after exporting env variables.
 
     See: https://github.com/cylc/cylc-rose/issues/237


### PR DESCRIPTION
Closes #237 

This is now ready for review but needs testing against https://github.com/cylc/cylc-flow/pull/5839.

Ensure that the cached globalconfig object is reloaded after the export of `CYLC_SYMLINKS` variable. This means that using the `CYLC_SYMLINKS` variable allows users to specify installation symlink locations in the `rose-suite.conf`.

n.b. I was surprised to find that running `glbl_cfg()._DEFAULT = None` did not clear the cached config in a way that would force the reload in Cylc, but I think just reloading the config in Cylc Rose makes at least as much sense.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] Docs: I have updated the plugin documentation.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
