### PR TITLE
GH Actions: separate lint vs test jobs

### DIFF
--- a/.github/workflows/branch_sync.yml
+++ b/.github/workflows/branch_sync.yml
@@ -1,0 +1,20 @@
+name: Sync PR
+
+on:
+  push:
+    branches:
+      - '*.*.x'
+  schedule:
+    - cron: '11 04 * * 1-5' # 04:11 UTC Mon-Fri
+  workflow_dispatch:
+    inputs:
+      head_branch:
+        description: Branch to merge into master
+        required: true
+
+jobs:
+  sync:
+    uses: cylc/release-actions/.github/workflows/branch-sync.yml@v1
+    with:
+      head_branch: ${{ inputs.head_branch }}
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '53 0 * * 1-5' # 00:53 Mon-Fri
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 2
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,11 +22,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9']
+      fail-fast: false
     env:
       PYTEST_ADDOPTS: --cov --cov-append --color=yes
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure Python
         uses: actions/setup-python@v4
@@ -32,22 +40,15 @@ jobs:
           cylc_flow: true
           cylc_flow_opts: 'empy'
           metomi_rose: true
-          metomi_rose_opts: 'tests'
+          metomi_rose_opts: ''
 
       - name: Install cylc-rose
         # need editable install for coverage
         run: |
-          pip install -e .[all]
-
-      - name: Style
-        run: |
-          flake8
-
-      - name: Mypy
-        run: mypy
+          pip install -e .[tests]
 
       - name: Checkout FCM
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.inputs.fcm_repo || 'metomi/fcm' }}
           ref: ${{ github.event.inputs.fcm_ref || 'master' }}
@@ -95,8 +96,52 @@ jobs:
           coverage xml
           coverage report
 
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage_py-${{ matrix.python-version }}
+          path: coverage.xml
+          retention-days: 4
+
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install cylc-rose
+        run: |
+          pip install -e .[lint]
+
+      - name: Style
+        run: flake8
+
+      - name: Mypy
+        run: mypy
+
+  codecov:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+
       - name: Codecov upload
         uses: codecov/codecov-action@v3
         with:
-          name: '${{ github.workflow }} py-${{ matrix.python-version }}'
-          fail_ci_if_error: false
+          name: ${{ github.workflow }}
+          fail_ci_if_error: true
+          verbose: true
+          # Token not required for public repos, but avoids upload failure due
+          # to rate-limiting (but not for PRs opened from forks)
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,6 +67,10 @@ include = cylc*
 [options.extras_require]
 tests =
     coverage>=5.0.0
+    pytest
+    pytest-cov
+    pytest-xdist>=2
+lint =
     flake8
     flake8-broken-line>=0.3.0
     flake8-bugbear>=21.0.0
@@ -77,11 +81,9 @@ tests =
     flake8-simplify>=0.15.1
     flake8-type-checking; python_version > "3.7"
     mypy>=0.910
-    pytest
-    pytest-cov
-    pytest-xdist>=2
 all =
     %(tests)s
+    %(lint)s
 
 [options.entry_points]
 cylc.pre_configure =

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -496,33 +496,24 @@ def with_config(
 
 
 class TestWithConfig:
-    @pytest.mark.parametrize(
-        'expected',
-        [
-            "run_ok",
-            (
-                "RUN_NAMES=[\'earl_grey\', \'milk\', \'sugar\', "
-                "\'spoon\', \'cup\', \'milk\']"
-            ),
-            "SOURCE_FOO=\"{workingcopy} fcm:foo.x_tr@head\"",
-            "HOST_SOURCE_FOO=\"{hostname}:{workingcopy} fcm:foo.x_tr@head\"",
-            "SOURCE_FOO_BASE=\"{workingcopy}\"",
-            "HOST_SOURCE_FOO_BASE=\"{hostname}:{workingcopy}\"",
-            "SOURCE_FOO_REV=\"\"",
-            "MILK=\"true\"",
-        ]
-    )
-    def test_with_config(self, with_config, expected, monkeypatch):
+    def test_with_config(self, with_config):
         """test for successful execution with site/user configuration
         """
-        if expected == 'run_ok':
-            assert with_config['run_stem'].returncode == 0
-        else:
-            expected = expected.format(
-                workingcopy=with_config['workingcopy'],
+        assert with_config['run_stem'].returncode == 0
+        for line in [
+            "RUN_NAMES=['earl_grey', 'milk', 'sugar', 'spoon', 'cup', 'milk']",
+            'SOURCE_FOO="{workingcopy} fcm:foo.x_tr@head"',
+            'HOST_SOURCE_FOO="{hostname}:{workingcopy} fcm:foo.x_tr@head"',
+            'SOURCE_FOO_BASE="{workingcopy}"',
+            'HOST_SOURCE_FOO_BASE="{hostname}:{workingcopy}"',
+            'SOURCE_FOO_REV=""',
+            'MILK="true"',
+        ]:
+            line = line.format(
+                **with_config,
                 hostname=HOST
             )
-            assert expected in with_config['jobout_content']
+            assert line in with_config['jobout_content']
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
`pip install` is currently failing on Python 3.7 due to conflicting dependencies related to flake8.

I have separated the linting and testing dependencies and separated them into different jobs on GH Actions

