### PR TITLE
Small doc update RE: `CYLC_VERSION`

### DIFF
--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -104,8 +104,8 @@ to the Cylc scheduler:
       suites. This is no longer possible, and if set in your
       ``ROSE_VERSION`` in your suite configuration it will be ignored.
 
+.. note::
 
-``CYLC_VERSION``
    .. deprecated:: 8.0.0
 
       ``CYLC_VERSION`` will be removed from your configuration by the


### PR DESCRIPTION
The line above says
> The Cylc Rose plugin provides two environment/template variables to the Cylc scheduler:

Then lists _three_. I have converted the `CYLC_VERSION` item into a note about its removal instead.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] No cylc-doc update needed
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
