### PR TITLE
Mock user config without creating a config file.

### DIFF
--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -499,7 +499,7 @@ class TestRelativePath:
 
 @pytest.fixture(scope='class')
 def with_config(
-    rose_stem_run_template, setup_stem_repo, mock_usr_cfg
+    rose_stem_run_template, setup_stem_repo, mock_global_cfg
 ):
     """test for successful execution with site/user configuration
     """
@@ -510,7 +510,7 @@ def with_config(
         'workflow_name': setup_stem_repo['suitename']
     }
 
-    mock_usr_cfg(['rose-stem', 'automatic-options'], 'MILK=true')
+    mock_global_cfg(['rose-stem', 'automatic-options'], 'MILK=true')
     yield rose_stem_run_template(rose_stem_opts)
 
 
@@ -537,7 +537,7 @@ class TestWithConfig:
 
 @pytest.fixture(scope='class')
 def with_config2(
-    rose_stem_run_template, setup_stem_repo, mock_usr_cfg
+    rose_stem_run_template, setup_stem_repo, mock_global_cfg
 ):
     """test for successful execution with site/user configuration
     """
@@ -547,7 +547,7 @@ def with_config2(
             f'{setup_stem_repo["workingcopy"]}'],
         'workflow_name': setup_stem_repo['suitename']
     }
-    mock_usr_cfg(
+    mock_global_cfg(
         ['rose-stem', 'automatic-options'], 'MILK=true TEA=darjeeling')
     yield rose_stem_run_template(rose_stem_opts)
 

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -73,6 +73,7 @@ from pathlib import Path
 from shlex import split
 from types import SimpleNamespace
 from uuid import uuid4
+from unittest.mock import MagicMock
 
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.hostuserutil import get_host
@@ -121,7 +122,7 @@ def mock_global_cfg(monkeymodule):
         node = ConfigLoader().load(StringIO(conf))
 
         # Create a fake class imitating ConfigTree with .get_conf method:
-        config = Mock(spec=['get_conf'], get_conf=lambda: node)
+        config = MagicMock(spec=['get_conf'], get_conf=lambda: node)
 
         monkeymodule.setattr(target, lambda *_, **__: config)
 
@@ -508,8 +509,8 @@ def with_config(
     }
 
     mock_global_cfg(
+        'cylc.rose.stem.ResourceLocator.default',
         '[rose-stem]\nautomatic-options = MILK=true',
-        'cylc.rose.stem.ResourceLocator.default'
     )
     yield rose_stem_run_template(rose_stem_opts)
 
@@ -548,8 +549,8 @@ def with_config2(
         'workflow_name': setup_stem_repo['suitename']
     }
     mock_global_cfg(
+        'cylc.rose.stem.ResourceLocator.default',
         '[rose-stem]\nautomatic-options = MILK=true TEA=darjeeling',
-        'cylc.rose.stem.ResourceLocator.default'
     )
     yield rose_stem_run_template(rose_stem_opts)
 

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -113,15 +113,15 @@ def mock_global_cfg(monkeymodule):
     """Mock the rose ResourceLocator.default
 
     Args (To _inner):
-        conf: A fake rose global config as a string.
         target: The module to patch.
+        conf: A fake rose global config as a string.
     """
-    def _inner(conf, target):
+    def _inner(target, conf):
         """Mock a config object with a config node."""
         node = ConfigLoader().load(StringIO(conf))
 
         # Create a fake class imitating ConfigTree with .get_conf method:
-        config = type('MockConfig', (object,), {'get_conf': lambda: node})
+        config = Mock(spec=['get_conf'], get_conf=lambda: node)
 
         monkeymodule.setattr(target, lambda *_, **__: config)
 

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -107,7 +107,7 @@ def monkeymodule():
 
 
 @pytest.fixture(scope='class')
-def mock_usr_cfg(monkeymodule):
+def mock_global_cfg(monkeymodule):
     """Mock the rose ResourceLocator.default
 
     Args (To _inner):


### PR DESCRIPTION
Prevents caching of the rose config from making some rose stem tests flaky.
As a side benefit it's a little quicker.

How to demonstrate the problem:

```console
test1="tests/functional/test_rose_fileinstall.py::test_rose_fileinstall_run"
test2="tests/functional/test_rose_stem.py::TestWithConfig"

pytest $test1 $test2
# ... fail
pytest $test2 $test1
# ... pass
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] This is a fix to testing, and does not need a change log entry or documentation changes.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
