### PR TITLE
Mock only a single method of the rose config object.

### DIFF
--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -120,7 +120,9 @@ def mock_global_cfg(monkeymodule):
         """Get the ResourceLocator.default and patch its get_conf method
         """
         obj = ResourceLocator.default()
-        obj.get_conf = lambda: ConfigLoader().load(StringIO(conf))
+        monkeymodule.setattr(
+            obj, 'get_conf', lambda: ConfigLoader().load(StringIO(conf))
+        )
 
         monkeymodule.setattr(target, lambda *_, **__: obj)
 

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -73,7 +73,6 @@ from pathlib import Path
 from shlex import split
 from types import SimpleNamespace
 from uuid import uuid4
-from unittest.mock import MagicMock
 
 from cylc.flow.pathutil import get_workflow_run_dir
 from cylc.flow.hostuserutil import get_host
@@ -118,13 +117,12 @@ def mock_global_cfg(monkeymodule):
         conf: A fake rose global config as a string.
     """
     def _inner(target, conf):
-        """Mock a config object with a config node."""
-        node = ConfigLoader().load(StringIO(conf))
+        """Get the ResourceLocator.default and patch its get_conf method
+        """
+        obj = ResourceLocator.default()
+        obj.get_conf = lambda: ConfigLoader().load(StringIO(conf))
 
-        # Create a fake class imitating ConfigTree with .get_conf method:
-        config = MagicMock(spec=['get_conf'], get_conf=lambda: node)
-
-        monkeymodule.setattr(target, lambda *_, **__: config)
+        monkeymodule.setattr(target, lambda *_, **__: obj)
 
     yield _inner
 


### PR DESCRIPTION
Small change to #289 to avoid the use of mock, and to change the Rose config object as little as possible.