### PR TITLE
use fqdn in rose-stem tests

### DIFF
--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -73,10 +73,9 @@ from io import StringIO
 from types import SimpleNamespace
 from uuid import uuid4
 
-from cylc.flow.hostuserutil import get_host
-
 
 from metomi.rose.config import ConfigLoader
+from metomi.rose.host_select import HostSelector
 from cylc.flow.pathutil import get_workflow_run_dir
 from metomi.rose.resource import ResourceLocator
 import pytest
@@ -87,7 +86,12 @@ from cylc.rose.stem import (
     rose_stem,
 )
 
-HOST = get_host()
+
+# We want to test Rose-Stem's insertion of the hostname,
+# not Rose's method of getting the hostname, so it doesn't
+# Matter that we are using the same host selector here as
+# in the module under test:
+HOST = HostSelector().get_local_host()
 
 
 class SubprocessesError(Exception):

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -87,7 +87,7 @@ from cylc.rose.stem import (
     rose_stem,
 )
 
-HOST = get_host().split('.')[0]
+HOST = get_host()
 
 
 class SubprocessesError(Exception):


### PR DESCRIPTION
This test failed (locally) due to a local change in config. On looking into the breakage I realized that we only wanted to test that the hostname as Rose finds it is inserted into the config. We aren't trying to check the rose localhost getting method in this test.

Tests related to #276 are still failing, but should pass once that PR and it's companions are merged.

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Change to testing, no test or doc changes required
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
