### PR TITLE
platforms: use processed workflow config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+## __cylc-rose-1.3.3 (<span actions:bind='release-date'>Awaiting Release</span>)__
+
+[#300](https://github.com/cylc/cylc-rose/pull/300) -
+Fix issues which could cause "fcm_make" and "rose_prune" tasks intermittently
+fail with the message
+"Workflow database is incompatible with Cylc x.y.z, or is corrupted".
+
 ## __cylc-rose-1.3.2 (<span actions:bind='release-date'>Released 2024-01-18</span>)__
 
 [#284](https://github.com/cylc/cylc-rose/pull/284) - Allow use of Metomi-Rose 2.2.*.

--- a/cylc/rose/platform_utils.py
+++ b/cylc/rose/platform_utils.py
@@ -25,7 +25,11 @@ from typing import Any, Dict
 
 from cylc.flow.config import WorkflowConfig
 from cylc.flow.id_cli import parse_id
-from cylc.flow.pathutil import get_workflow_run_pub_db_path
+from cylc.flow.pathutil import (
+    get_workflow_run_config_log_dir,
+    get_workflow_run_pub_db_path,
+)
+from cylc.flow.workflow_files import WorkflowFiles
 from cylc.flow.platforms import (
     HOST_REC_COMMAND,
     get_platform,
@@ -47,7 +51,11 @@ def get_platform_from_task_def(flow: str, task: str) -> Dict[str, Any]:
     Returns:
         Platform Dictionary.
     """
-    _, _, flow_file = parse_id(flow, constraint='workflows', src=True)
+    workflow_id, _, _ = parse_id(flow, constraint='workflows', src=True)
+    flow_file = get_workflow_run_config_log_dir(
+        workflow_id,
+        WorkflowFiles.FLOW_FILE_PROCESSED,
+    )
     config = WorkflowConfig(flow, flow_file, Values())
     # Get entire task spec to allow Cylc 7 platform from host guessing.
     task_spec = config.pcfg.get(['runtime', task])

--- a/tests/unit/test_platform_utils.py
+++ b/tests/unit/test_platform_utils.py
@@ -119,7 +119,8 @@ def fake_flow():
     flow_name: str = f'cylc-rose-platform-utils-test-{str(uuid4())[:6]}'
     flow_path = Path(os.path.expandvars('$HOME/cylc-run')) / flow_name
     flow_path.mkdir(parents=True)
-    (flow_path / 'flow.cylc').write_text("""
+    flow_cylc = flow_path / 'flow.cylc'
+    flow_cylc.write_text("""
         [scheduling]
             [[graph]]
                 R1 = foo & bar & baz & qux & child_of_bar
@@ -143,10 +144,12 @@ def fake_flow():
             [[child_of_bar]]
                 inherit = BAR
     """)
+    flow_processed = flow_path / 'log/config/flow-processed.cylc'
+    flow_processed.parent.mkdir(exist_ok=True, parents=True)
+    flow_processed.symlink_to(flow_path / 'flow.cylc')
 
     # Set up a database
     db_file = get_workflow_run_pub_db_path(flow_name)
-    Path(db_file).parent.mkdir()
     with CylcWorkflowDAO(db_file, create_tables=True) as dao:
         conn = dao.connect()
         conn.execute(


### PR DESCRIPTION
* When retrieving the platform used by a task, use the processed workflow config rather than processing the config from scratch.
* This avoids the need to access the DB to extract template variables (workflow params) which could cause public DB locking issues.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.