### PR TITLE
De-flake tests (Avoid cleanup errors when using -n > 1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Test
         run: |
-          pytest tests/
+          pytest -n 5 tests/
 
       - name: Doctest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Test
         run: |
-          pytest -n 5 tests/
+          pytest tests/
 
       - name: Doctest
         run: |

--- a/tests/functional/test_reinstall.py
+++ b/tests/functional/test_reinstall.py
@@ -37,6 +37,7 @@ from cylc.flow.hostuserutil import get_host
 from cylc.flow.install import reinstall_workflow
 from cylc.flow.pathutil import get_workflow_run_dir
 import pytest
+from xdist import is_xdist_controller
 
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING as ROHIOS,
@@ -72,7 +73,7 @@ def fixture_provide_flow(tmp_path_factory, request):
         'flowpath': flowpath,
         'srcpath': srcpath
     }
-    if not request.session.testsfailed:
+    if is_xdist_controller(request) and not request.session.testsfailed:
         shutil.rmtree(srcpath)
         shutil.rmtree(flowpath)
 

--- a/tests/functional/test_reinstall_clean.py
+++ b/tests/functional/test_reinstall_clean.py
@@ -35,6 +35,7 @@ from uuid import uuid4
 from cylc.flow.hostuserutil import get_host
 from cylc.flow.pathutil import get_workflow_run_dir
 import pytest
+from xdist import is_xdist_controller
 
 from cylc.rose.utilities import (
     ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING as ROHIOS,
@@ -70,7 +71,10 @@ def fixture_provide_flow(tmp_path_factory, request):
         'flowpath': flowpath,
         'srcpath': srcpath
     }
-    if not request.session.testsfailed:
+    if (
+        is_xdist_controller(request)
+        and not request.session.testsfailed
+    ):
         shutil.rmtree(srcpath)
         shutil.rmtree(flowpath)
 


### PR DESCRIPTION
Closes #325 

Only run clean up tests in controller worker to prevent cleanup errors: Flaky tests were being caused by errors in cleanup when tests were distributed and some workers attempted to cleanup before other workers were finished with the same fixture.

Tested by running:

```bash
# Crank n up as high as you think that you can get away with.
> for i in $(seq 1 50); do pytest -n 24 >> repeater.txt; done

# 🍵 🛌🏼 🌅  (Go have a cuppa, or leave it overnight)

> grep '224 passed in' repeater.txt | wc -l
...
> grep Error repeater.txt
# Hopefully nothing
```

I have also checked that 
```bash
# Master
du -h --max-depth=0 /var/tmp/pytest-of-tpilling/pytest-1746/popen-gw0
316K	/var/tmp/pytest-of-tpilling/pytest-1746/popen-gw0

# This branch
du -h --max-depth=0 /var/tmp/pytest-of-me/pytest-1747/popen-gw0
316K	/var/tmp/pytest-of-me/pytest-1746/popen-gw0
```


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] `CHANGES.md` entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.
