### PR TITLE
glbl_cfg: reload without mutating the original

### DIFF
--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -876,7 +876,7 @@ def export_environment(environment: Dict[str, str]) -> None:
     # can be used by Jinja2 in the global config.
     # https://github.com/cylc/cylc-rose/issues/237
     if environment:
-        glbl_cfg().load()
+        glbl_cfg(reload=True)
 
 
 def record_cylc_install_options(

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ python_requires = >=3.7
 include_package_data = True
 install_requires =
     metomi-rose==2.3.*
-    cylc-flow==8.3.*
+    cylc-flow>=8.3.3.dev,<8.4
     metomi-isodatetime
     ansimarkup
     jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ python_requires = >=3.7
 include_package_data = True
 install_requires =
     metomi-rose==2.3.*
-    cylc-flow>=8.3.3.dev,<8.4
+    cylc-flow>8.3.2,<8.4
     metomi-isodatetime
     ansimarkup
     jinja2


### PR DESCRIPTION
Sibling: https://github.com/cylc/cylc-flow/pull/6249

* Use the new `reload` kwarg rather than calling the `.load()` method.
* Fixes https://github.com/cylc/cylc-flow/issues/6244
* The `.load()` method mutates the existing config, due to the use of logging within (and outside of) this routine and the use of `glbl_cfg` in the logging, this created a race condition.
* The new `reload` kwarg creates a new config instance, then sets this as the default.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (test for the original feature added in the PR - https://github.com/cylc/cylc-rose/pull/269, tests for the bugfix in the cylc-flow PR)
- [x] Changelog entry (added an entry in cylc-flow)
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.