### PR TITLE
Fix test broken by Cylc 8.4 better handling of Jinja2 error

### DIFF
--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -257,7 +257,7 @@ async def test_validate_against_source(
         wid, {"against_source": True, 'clear_rose_install_opts': True}
     )
     assert clear_install_validate.ret != 0
-    assert 'Jinja2 Assertion Error' in str(clear_install_validate.exc.args[0])
+    assert 'Test --rose-template-variable' in str(clear_install_validate.exc)
 
 
 def test_invalid_cli_opts(tmp_path, caplog):


### PR DESCRIPTION
Test relied on changed logging output from Cylc validate.

Broken by https://github.com/cylc/cylc-flow/pull/6289
