### PR TITLE
stem: use Cylc host selection interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ creating a new release entry be sure to copy & paste the span tag with the
 updated. Only the first match gets replaced, so it's fine to leave the old
 ones in. -->
 
+## __cylc-rose-1.5.0 (<span actions:bind='release-date'>Awaiting release</span>)__
+
+[#361](https://github.com/cylc/cylc-rose/pull/361) -
+Rose stem now uses long hostnames for the `HOST_SOURCE...` variables to match
+`ROSE_ORIG_HOST`.
+
 ## __cylc-rose-1.5.0 (<span actions:bind='release-date'>Released 2025-01-09</span>)__
 
 [#353](https://github.com/cylc/cylc-rose/pull/353) - Remove Empy support.

--- a/cylc/rose/stem.py
+++ b/cylc/rose/stem.py
@@ -68,12 +68,14 @@ import re
 import sys
 
 from ansimarkup import parse as cparse
+
 from cylc.flow.exceptions import CylcError
+from cylc.flow.hostuserutil import get_host
 from cylc.flow.scripts.install import get_option_parser
 from cylc.flow.scripts.install import install as cylc_install
+
 import metomi.rose.config
 from metomi.rose.fs_util import FileSystemUtil
-from metomi.rose.host_select import HostSelector
 from metomi.rose.popen import RosePopener
 from metomi.rose.reporter import Event, Reporter
 from metomi.rose.resource import ResourceLocator
@@ -239,8 +241,6 @@ class StemRunner:
         else:
             self.fs_util = fs_util
 
-        self.host_selector = HostSelector(event_handler=self.reporter,
-                                          popen=self.popen)
         self.template_section = '[template variables]'
 
     def _add_define_option(self, var, val):
@@ -429,7 +429,7 @@ class StemRunner:
         locations."""
         if ':' not in url or url.split(':', 1)[0] not in ['svn', 'fcm', 'http',
                                                           'https', 'svn+ssh']:
-            url = self.host_selector.get_local_host() + ':' + url
+            url = f'{get_host()}:{url}'
         return url
 
     def _parse_auto_opts(self):

--- a/tests/functional/test_rose_stem.py
+++ b/tests/functional/test_rose_stem.py
@@ -28,9 +28,9 @@ import subprocess
 from uuid import uuid4
 from typing import Dict
 
-from metomi.rose.host_select import HostSelector
-
 import pytest
+
+from cylc.flow.hostuserutil import get_host
 
 from cylc.rose.stem import RoseStemVersionException
 
@@ -38,7 +38,7 @@ from cylc.rose.stem import RoseStemVersionException
 # not Rose's method of getting the hostname, so it doesn't
 # Matter that we are using the same host selector here as
 # in the module under test:
-HOST = HostSelector().get_local_host()
+HOST = get_host()
 
 
 # Check that FCM is present on system, skipping checks elsewise:


### PR DESCRIPTION
* The `ROSE_ORIG_HOST` variable is set using the Cylc interface.
* The `HOST_SOURCE...` rose-stem variables are set using the Rose interface.
* The two interfaces differ, Cylc picks long hostnames, Rose picks short ones.
* The inconsistency may cause issues with simplistic "is this localhost" checks.
* The shortnames are causing issues at one site.
* Switch to using the Cylc interface for all scenarios.


**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [X] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [ ] Changelog entry included if this is a change that can affect users
- [X] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [X] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.