### PR TITLE
actions: use mamba to provision Python environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,13 +15,17 @@ concurrency:
 env:
   FORCE_COLOR: 2
 
+defaults:
+  run:
+    shell: micromamba-shell {0}
+
 jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3']
       fail-fast: false
     env:
       PYTEST_ADDOPTS: --cov --cov-append --color=yes
@@ -30,9 +34,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          generate-run-shell: true
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: cylc
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - name: install libs
         uses: cylc/release-actions/install-cylc-components@v1
@@ -111,9 +120,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure Python
-        uses: actions/setup-python@v5
+        uses: mamba-org/setup-micromamba@v2
         with:
-          python-version: '3.9'
+          generate-run-shell: true
+          cache-environment: true
+          post-cleanup: 'all'
+          environment-name: cylc
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - name: install libs
         uses: cylc/release-actions/install-cylc-components@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ env:
 
 defaults:
   run:
-    shell: micromamba-shell {0}
+    shell: bash -elo pipefail {0}
 
 jobs:
   test:
@@ -36,7 +36,6 @@ jobs:
       - name: Configure Python
         uses: mamba-org/setup-micromamba@v2
         with:
-          generate-run-shell: true
           cache-environment: true
           post-cleanup: 'all'
           environment-name: cylc
@@ -122,7 +121,6 @@ jobs:
       - name: Configure Python
         uses: mamba-org/setup-micromamba@v2
         with:
-          generate-run-shell: true
           cache-environment: true
           post-cleanup: 'all'
           environment-name: cylc


### PR DESCRIPTION
* Fixes test failures.
* Get Python from conda-forge rather than the OS vendor.
* Fixes Python 3.7 tests (currently broken due to OS support).
* Test with all supported Python versions.
* Requires https://github.com/cylc/release-actions/pull/100