### PR TITLE
remove redundant error check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,9 +16,9 @@ coverage:
     project:
       default:
         # fail if coverage below this:
-        target: '67%'
+        target: '97%'
         # fail if coverage drops by this much:
-        threshold: '2%'
+        threshold: '0%'
     patch:
       default:
         target: '90%'

--- a/.mailmap
+++ b/.mailmap
@@ -10,3 +10,4 @@ Tim Pillinger          <tim.pillinger@metoffice.gov.uk>                         
 github-actions[bot]    <github-actions@no-reply.github.com>                        <41898282+github-actions[bot]@users.noreply.github.com>
 Hilary Oliver          <hilary.j.oliver@gmail.com>          Hilary James Oliver
 Christopher Bennett    <christopher.bennett@metoffice.gov.uk>
+Samuel Denton          <samuel.denton@metoffice.gov.uk>     samuel-denton          <samuel.denton@metoffice.gov.uk>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ below.
  - Jonny Williams
  - Mark Dawson
  - Christopher Bennett
+ - Samuel Denton
 <!-- end-shortlog -->
 
 (All contributors are identifiable with email addresses in the git version

--- a/cylc/rose/entry_points.py
+++ b/cylc/rose/entry_points.py
@@ -81,8 +81,7 @@ def post_install(srcdir: Path, rundir: str, opts: 'Values') -> bool:
 
     # perform file installation
     config_node = rose_fileinstall(_rundir, opts)
-    if config_node:
-        dump_rose_log(rundir=_rundir, node=config_node)
+    dump_rose_log(rundir=_rundir, node=config_node)
 
     # Having dumped the config we clear rose options
     # as they do not apply after this.

--- a/cylc/rose/fileinstall.py
+++ b/cylc/rose/fileinstall.py
@@ -17,9 +17,9 @@
 """Utilities related to performing Rose file installation."""
 
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
-from cylc.rose.utilities import rose_config_exists, rose_config_tree_loader
+from cylc.rose.utilities import rose_config_tree_loader
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -30,11 +30,8 @@ if TYPE_CHECKING:
 def rose_fileinstall(
     rundir: 'Path',
     opts: 'Values',
-) -> 'Union[ConfigNode, bool]':
+) -> 'ConfigNode':
     """Call Rose Fileinstall."""
-    if not rose_config_exists(rundir):
-        return False
-
     # Load the config tree
     config_tree = rose_config_tree_loader(rundir, opts)
 

--- a/tests/functional/test_post_install.py
+++ b/tests/functional/test_post_install.py
@@ -302,10 +302,6 @@ def test_rose_fileinstall_exception(tmp_path, monkeypatch):
         'cylc.rose.utilities.rose_config_tree_loader',
         fakenode,
     )
-    monkeypatch.setattr(
-        'cylc.rose.fileinstall.rose_config_exists',
-        lambda x: True,
-    )
     with pytest.raises(FileNotFoundError):
         rose_fileinstall('/oiruhgaqhnaigujhj', SimpleNamespace())
 


### PR DESCRIPTION
Remove a redundant error check and bump the coverage threshold.

(This is the cylc-rose repository. It provides a cylc-flow plugin for [metomi-rose](github.com/metomi/rose/).)

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.