### PR TITLE
remove Cylc 7 compatibility mode

### DIFF
--- a/changes.d/429.break.md
+++ b/changes.d/429.break.md
@@ -1,1 +1,1 @@
-Legacy support for zero-prefixed integers (e.g, `01`, `02`, `03` as opposed to `1`, `2`, `3`) has been removed. This support was dropped in Jinja2 v3.0, but support was extended in cylc-rose past this date in order to facilitate Cylc 7/8 interoperability.
+Legacy support for zero-prefixed integers in template variables (e.g, `01`, `02`, `03` as opposed to `1`, `2`, `3`) has been removed. This support was dropped in Jinja2 v3.0, but support was extended in cylc-rose past this date in order to facilitate Cylc 7/8 interoperability.

--- a/changes.d/429.break.md
+++ b/changes.d/429.break.md
@@ -1,0 +1,1 @@
+Legacy support for zero-prefixed integers (e.g, `01`, `02`, `03` as opposed to `1`, `2`, `3`) has been removed. This support was dropped in Jinja2 v3.0, but support was extended in cylc-rose past this date in order to facilitate Cylc 7/8 interoperability.

--- a/cylc/rose/__init__.py
+++ b/cylc/rose/__init__.py
@@ -65,9 +65,8 @@ The following sections are permitted in the ``rose-suite.conf`` files:
 
 .. note::
 
-   For compatibility with Cylc 7, section ``[suite.rc:jinja2]`` will be
-   processed, but is deprecated and provided for ease of porting Cylc 7
-   workflows.
+   The legacy ``[suite.rc:jinja2]`` section remains supported, but is
+   deprecated, please rename it to ``[template variables]``.
 
 
 The ``global.cylc`` file

--- a/cylc/rose/jinja2_parser.py
+++ b/cylc/rose/jinja2_parser.py
@@ -16,12 +16,8 @@
 """Utility for parsing Jinja2 expressions."""
 
 from ast import literal_eval as python_literal_eval
-from contextlib import contextmanager
-from copy import deepcopy
 import re
 
-from cylc.flow import LOG
-import jinja2.lexer
 from jinja2.nativetypes import NativeEnvironment  # type: ignore
 from jinja2.nodes import (  # type: ignore
     Literal,
@@ -31,157 +27,6 @@ from jinja2.nodes import (  # type: ignore
     Pos,
     Template,
 )
-
-
-def _strip_leading_zeros(string):
-    """Strip leading zeros from a string.
-
-    Examples:
-        >>> _strip_leading_zeros('1')
-        '1'
-        >>> _strip_leading_zeros('01')
-        '1'
-        >>> _strip_leading_zeros('001')
-        '1'
-        >>> _strip_leading_zeros('0001')
-        '1'
-        >>> _strip_leading_zeros('0')
-        '0'
-        >>> _strip_leading_zeros('000')
-        '0'
-
-    """
-    ret = string.lstrip('0')
-    return ret or '0'
-
-
-def _lexer_wrap(fcn):
-    """Helper for patch_jinja2_leading_zeros.
-
-    Patches the jinja2.lexer.Lexer.wrap method.
-    """
-    instances = set()  # record of uses of deprecated syntax
-
-    def _stream(stream):
-        """Patch the token stream to strip the leading zero where necessary."""
-        for lineno, token, value_str in stream:
-            if (
-                token == jinja2.lexer.TOKEN_INTEGER
-                and len(value_str) > 1
-                and value_str[0] == '0'
-            ):
-                instances.add(value_str)
-            yield (lineno, token, _strip_leading_zeros(value_str))
-
-    def _inner(
-        self,
-        stream,  # : t.Iterable[t.Tuple[int, str, str]],
-        name,  # : t.Optional[str] = None,
-        filename,  # : t.Optional[str] = None,
-    ):  # -> t.Iterator[Token]:
-        return fcn(self, _stream(stream), name, filename)
-
-    _inner.__wrapped__ = fcn  # save the un-patched function
-    _inner._instances = instances  # save the set of uses of deprecated syntax
-
-    return _inner
-
-
-@contextmanager
-def patch_jinja2_leading_zeros():
-    """Back support integers with leading zeros in Jinja2 v3.
-
-    Jinja2 v3 dropped support for integers with leading zeros, these are
-    heavily used throughout Rose configurations. Since there was no deprecation
-    warning in Jinja2 v2 we have implemented this patch to extend support for
-    a short period to help our users to transition.
-
-    This patch will issue a warning if usage of the deprecated syntax is
-    detected during the course of its usage.
-
-    Warning:
-        This is a *global* patch applied to the Jinja2 library whilst the
-        context manager is open. Do not use this with parallel/async code
-        as the patch could apply to code outside of the context manager.
-
-    Examples:
-        >>> env = NativeEnvironment()
-
-        The integer "1" is ok:
-        >>> env.parse('{{ 1 }}')
-        Template(body=[Output(nodes=[Const(value=1)])])
-
-        However "01" is no longer supported:
-        >>> env.parse('{{ 01 }}')
-        Traceback (most recent call last):
-        jinja2.exceptions.TemplateSyntaxError: expected token ...
-
-        The patch returns support (the leading-zero gets stripped):
-        >>> with patch_jinja2_leading_zeros():
-        ...     env.parse('{{ 01 }}')
-        Template(body=[Output(nodes=[Const(value=1)])])
-
-        The patch can handle any number of arbitrary leading zeros:
-        >>> with patch_jinja2_leading_zeros():
-        ...     env.parse('{{ 0000000001 }}')
-        Template(body=[Output(nodes=[Const(value=1)])])
-
-        Once the "with" closes we go back to vanilla Jinja2 behaviour:
-        >>> env.parse('{{ 01 }}')
-        Traceback (most recent call last):
-        jinja2.exceptions.TemplateSyntaxError: expected token ...
-
-    """
-    # clear any previously cashed lexer instances
-    jinja2.lexer._lexer_cache.clear()
-
-    # apply the code patch (new lexer instances will pick up these changes)
-    _integer_re = deepcopy(jinja2.lexer.integer_re)
-    jinja2.lexer.integer_re = re.compile(
-        rf'''
-            # Jinja2 no longer recognises zero-padded integers as integers
-            # so we must patch its regex to allow them to be detected.
-            (
-                [0-9](_?\d)* # decimal (which supports zero-padded integers)
-                |
-                {jinja2.lexer.integer_re.pattern}
-            )
-        ''',
-        re.IGNORECASE | re.VERBOSE,
-    )
-    jinja2.lexer.Lexer.wrap = _lexer_wrap(jinja2.lexer.Lexer.wrap)
-
-    # execute the body of the "with" statement
-    try:
-        yield
-    finally:
-        # report any usage of deprecated syntax
-        if jinja2.lexer.Lexer.wrap._instances:
-            num_examples = 5
-            LOG.warning(
-                'Support for integers with leading zeros (including'
-                ' lists of integers) was dropped in Jinja2 v3.'
-                ' Rose will extend support until a future version.'
-                '\nPlease amend your Rose configuration files,'
-                ' which currently contain:'
-                '\n * '
-                + (
-                    '\n * '.join(
-                        f'{before} => {_strip_leading_zeros(before)}'
-                        for before in list(
-                            jinja2.lexer.Lexer.wrap._instances
-                        )[:num_examples]
-                    )
-                )
-
-            )
-
-        # revert the code patch
-        jinja2.lexer.integer_re = _integer_re
-        jinja2.lexer.Lexer.wrap = jinja2.lexer.Lexer.wrap.__wrapped__
-
-        # clear any patched lexers to return Jinja2 to normal operation
-        jinja2.lexer._lexer_cache.clear()
 
 
 class Parser(NativeEnvironment):
@@ -247,11 +92,6 @@ class Parser(NativeEnvironment):
             'a string'
             >>> parser.literal_eval('1,\n2,\n3')
             (1, 2, 3)
-
-            # back-supported jinja2 variants
-            >>> with patch_jinja2_leading_zeros():
-            ...     parser.literal_eval('042')
-            42
 
             # invalid examples
             >>> parser.literal_eval('1 + 1')

--- a/cylc/rose/platform_utils.py
+++ b/cylc/rose/platform_utils.py
@@ -19,7 +19,6 @@
 """Interfaces for Cylc Platforms for use by rose apps."""
 
 from optparse import Values
-from pathlib import Path
 import sqlite3
 import subprocess
 import sys
@@ -28,7 +27,6 @@ from typing import (
     Any,
     Dict,
     Tuple,
-    Union,
 )
 
 from cylc.flow.config import WorkflowConfig
@@ -36,7 +34,6 @@ from cylc.flow.exceptions import PlatformLookupError
 from cylc.flow.id_cli import parse_id
 from cylc.flow.pathutil import (
     get_workflow_run_config_log_dir,
-    get_workflow_run_dir,
     get_workflow_run_pub_db_path,
 )
 from cylc.flow.platforms import (
@@ -67,11 +64,7 @@ def get_platform_from_task_def(flow: str, task: str) -> Dict[str, Any]:
         WorkflowFiles.FLOW_FILE_PROCESSED,
     )
 
-    config = WorkflowConfig(
-        flow,
-        flow_file, Values(),
-        force_compat_mode=get_compat_mode(get_workflow_run_dir(workflow_id))
-    )
+    config = WorkflowConfig(flow, flow_file, Values())
     # Get entire task spec to allow Cylc 7 platform from host guessing.
     task_spec = config.pcfg.get(['runtime', task])
     # check for subshell and evaluate
@@ -88,17 +81,6 @@ def get_platform_from_task_def(flow: str, task: str) -> Dict[str, Any]:
             task_spec['remote']['host'])
     platform = get_platform(task_spec)
     return platform
-
-
-def get_compat_mode(run_dir: Union[str, Path]) -> bool:
-    """Check whether this is a Cylc 7 Back compatibility mode workflow:
-
-    See https://github.com/cylc/cylc-rose/issues/319
-
-    Args:
-        run_dir: Cylc workflow run directory.
-    """
-    return (Path(run_dir) / WorkflowFiles.SUITE_RC).exists()
 
 
 def eval_subshell(platform):

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -52,7 +52,7 @@ from metomi.rose.config_processor import ConfigProcessError
 from metomi.rose.config_tree import ConfigTree
 from metomi.rose.env import UnboundEnvironmentVariableError, env_var_process
 
-from cylc.rose.jinja2_parser import Parser, patch_jinja2_leading_zeros
+from cylc.rose.jinja2_parser import Parser
 
 if TYPE_CHECKING:
     from cylc.flow.option_parsers import Values
@@ -184,26 +184,22 @@ def process_config(
 
     # Add the entire plugin_result to ROSE_SUITE_VARIABLES to allow for
     # programatic access.
-    with patch_jinja2_leading_zeros():
-        # BACK COMPAT: patch_jinja2_leading_zeros
-        # back support zero-padded integers for a limited time to help
-        # users migrate before upgrading cylc-flow to Jinja2>=3.1
-        parser = Parser()
-        for key, value in plugin_result['template_variables'].items():
-            # The special variables are already Python variables.
-            if key not in ['ROSE_ORIG_HOST', 'ROSE_VERSION', 'ROSE_SITE']:
-                try:
-                    plugin_result['template_variables'][key] = (
-                        parser.literal_eval(value)
-                    )
-                except Exception:
-                    raise ConfigProcessError(
-                        [templating, key],
-                        value,
-                        f'Invalid template variable: {value}'
-                        '\nMust be a valid Python or Jinja2 literal'
-                        ' (note strings "must be quoted").',
-                    ) from None
+    parser = Parser()
+    for key, value in plugin_result['template_variables'].items():
+        # The special variables are already Python variables.
+        if key not in ['ROSE_ORIG_HOST', 'ROSE_VERSION', 'ROSE_SITE']:
+            try:
+                plugin_result['template_variables'][key] = (
+                    parser.literal_eval(value)
+                )
+            except Exception:
+                raise ConfigProcessError(
+                    [templating, key],
+                    value,
+                    f'Invalid template variable: {value}'
+                    '\nMust be a valid Python or Jinja2 literal'
+                    ' (note strings "must be quoted").',
+                ) from None
 
     # Add ROSE_SUITE_VARIABLES to plugin_result of templating engines in use.
     plugin_result['template_variables']['ROSE_SUITE_VARIABLES'] = (

--- a/cylc/rose/utilities.py
+++ b/cylc/rose/utilities.py
@@ -36,7 +36,6 @@ from typing import (
 
 from cylc.flow import LOG
 from cylc.flow.exceptions import CylcError
-from cylc.flow.flags import cylc7_back_compat
 from cylc.flow.cfgspec.glbl_cfg import glbl_cfg
 from cylc.flow.hostuserutil import get_host
 from metomi.isodatetime.datetimeoper import DateTimeOperator
@@ -65,8 +64,6 @@ SET_BY_CYLC = 'set by Cylc'
 ROSE_ORIG_HOST_INSTALLED_OVERRIDE_STRING = (
     ' ROSE_ORIG_HOST set by cylc install.'
 )
-MESSAGE = 'message'
-ALL_MODES = 'all modes'
 STANDARD_VARS = [
     ('ROSE_ORIG_HOST', get_host()),
     ('ROSE_VERSION', ROSE_VERSION),
@@ -774,42 +771,30 @@ def deprecation_warnings(config_tree):
         - "root-dir"
         - "jinja2:suite.rc"
         - root-dir
-
-    If ALL_MODES is True this deprecation will ignore whether there is a
-    flow.cylc or suite.rc in the workflow directory.
     """
-
-    deprecations = {
-        'jinja2:suite.rc': {
-            MESSAGE: (
-                "'rose-suite.conf[jinja2:suite.rc]' is deprecated."
-                " Use [template variables] instead."
-            ),
-            ALL_MODES: False,
-        },
-        'jinja2:flow.cylc': {
-            MESSAGE: (
-                "'rose-suite.conf[jinja2:flow.cylc]' is not used by Cylc."
-                " Use [template variables] instead."
-            ),
-            ALL_MODES: False,
-        },
-        'root-dir': {
-            MESSAGE: (
-                'You have set "rose-suite.conf[root-dir]", '
-                'which is not supported at '
-                'Cylc 8. Use `[install] symlink dirs` in global.cylc '
-                'instead.'
-            ),
-            ALL_MODES: True,
-        },
-    }
+    deprecations = (
+        (
+            'jinja2:suite.rc',
+            "'rose-suite.conf[jinja2:suite.rc]' is deprecated."
+            " Use [template variables] instead.",
+        ),
+        (
+            'jinja2:flow.cylc',
+            "'rose-suite.conf[jinja2:flow.cylc]' is not used by Cylc."
+            " Use [template variables] instead.",
+        ),
+        (
+            'root-dir',
+            'You have set "rose-suite.conf[root-dir]", '
+            'which is not supported at '
+            'Cylc 8. Use `[install] symlink dirs` in global.cylc '
+            'instead.',
+        ),
+    )
     for string in list(config_tree.node):
-        for name, info in deprecations.items():
-            if (
-                info[ALL_MODES] or not cylc7_back_compat
-            ) and name in string.lower():
-                LOG.warning(info[MESSAGE])
+        for name, info in deprecations:
+            if name in string.lower():
+                LOG.warning(info)
 
 
 def load_rose_config(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,16 +187,12 @@ def _pytest_passed(request: pytest.FixtureRequest) -> bool:
 def _cylc_inspection_cli(capsys, caplog, script, gop):
     """Access the CLI for cylc scripts inspecting configurations
     """
-    async def _inner(srcpath, args=None, n_args=3):
+    async def _inner(srcpath, args=None):
         parser = gop()
         options = Options(parser, args)()
         output = SimpleNamespace()
 
-        if n_args == 3:
-            await script(parser, options, str(srcpath))
-        if n_args == 2:
-            # Don't include the parser:
-            await script(options, str(srcpath))
+        await script(options, str(srcpath))
 
         output.logging = '\n'.join([i.message for i in caplog.records])
         output.out, output.err = capsys.readouterr()
@@ -310,13 +306,13 @@ async def cylc_inspect_scripts(capsys, caplog):
         results = {}
 
         # Handle scripts taking a parser or just the output of the parser:
-        for script_name, n_args in {
-            'config': 3,
-            'list': 2,
-            'graph': 2,
-            'view': 2,
-            'validate': 3,
-        }.items():
+        for script_name in (
+            'config',
+            'list',
+            'graph',
+            'view',
+            'validate',
+        ):
 
             # Import the script modules:
             script_module = importlib.import_module(
@@ -330,7 +326,7 @@ async def cylc_inspect_scripts(capsys, caplog):
                 script = script_module.run
             else:
                 raise UsageError(
-                    f'Script "{script}\'s" module does not contain a '
+                    f'"{script_name}\" does not contain a '
                     '"_main" or "run" function'
                 )
 
@@ -343,7 +339,7 @@ async def cylc_inspect_scripts(capsys, caplog):
                 caplog,
                 script,
                 script_module.get_option_parser,
-            )(wid, args, n_args=n_args)
+            )(wid, args)
 
         # Return results for more checking if required:
         return results

--- a/tests/functional/test_pre_configure.py
+++ b/tests/functional/test_pre_configure.py
@@ -111,33 +111,18 @@ def test_warn_if_root_dir_set(root_dir_config, tmp_path, caplog):
 
 
 @pytest.mark.parametrize(
-    'compat_mode',
-    [
-        pytest.param(True, id='back-compat'),
-        pytest.param(False, id='no-back-compat')
-    ]
-)
-@pytest.mark.parametrize(
     'rose_config', [
         'jinja2:suite.rc',
         'jinja2:flow.cylc',
         'JinjA2:flOw.cylC',
     ]
 )
-def test_warn_if_old_templating_set(
-    compat_mode, rose_config, tmp_path, caplog, monkeypatch
-):
+def test_warn_if_old_templating_set(rose_config, tmp_path, caplog):
     """Test using unsupported root-dir config raises error."""
-    monkeypatch.setattr(
-        'cylc.rose.utilities.cylc7_back_compat', compat_mode
-    )
     (tmp_path / 'rose-suite.conf').write_text(f'[{rose_config}]')
     load_rose_config(tmp_path)
     msg = "Use [template variables]"
-    if compat_mode:
-        assert not caplog.records
-    else:
-        assert msg in caplog.records[0].message
+    assert msg in caplog.records[0].message
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_config_node.py
+++ b/tests/unit/test_config_node.py
@@ -281,27 +281,8 @@ def test_ROSE_ORIG_HOST_replacement_behaviour(
         assert node['env']['ROSE_ORIG_HOST'].value == 'IMPLAUSIBLE_HOST_NAME'
 
 
-@pytest.mark.parametrize(
-    'compat_mode, must_include, must_exclude',
-    (
-        (True, None, 'Use [template variables]'),
-        (True, 'root-dir', None),
-        (False, 'Use [template variables]', None),
-        (False, 'root-dir', None),
-    )
-)
-def test_deprecation_warnings(
-    caplog, monkeypatch, compat_mode, must_include, must_exclude
-):
-    """Method logs warnings correctly.
-
-    Two node items are set:
-
-    * ``jinja2:suite.rc`` should not cause a warning in compatibility mode.
-    * ``root-dir=/somewhere`` should always lead to a warning being logged.
-
-    Error messages about
-    """
+def test_deprecation_warnings(caplog):
+    """It should warn over deprecated Rose config sections."""
     # Create a node to pass to the method
     # (It's not a tree test because we can use a simpleNamespace in place of
     # a tree object):
@@ -310,16 +291,13 @@ def test_deprecation_warnings(
     node.set(['root-dir', '~foo'])
     tree = SimpleNamespace(node=node)
 
-    # Patch compatibility mode flag and run the function under test:
-    monkeypatch.setattr('cylc.rose.utilities.cylc7_back_compat', compat_mode)
     deprecation_warnings(tree)
 
     # Check that warnings have/not been logged:
-    records = '\n'.join([i.message for i in caplog.records])
-    if must_include:
-        assert must_include in records
-    else:
-        assert must_exclude not in records
+    records = '\n'.join(i.message for i in caplog.records)
+
+    assert 'root-dir' in records
+    assert 'Use [template variables]' in records
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_platform_utils.py
+++ b/tests/unit/test_platform_utils.py
@@ -25,7 +25,6 @@ import sqlite3
 from uuid import uuid4
 
 from cylc.rose.platform_utils import (
-    get_compat_mode,
     get_platform_from_task_def,
     get_platforms_from_task_jobs,
 )
@@ -213,24 +212,6 @@ def test_get_platform_from_task_def_subshell(
     mock_glbl_cfg(*MOCK_GLBL_CFG)
     platform = get_platform_from_task_def(fake_flow[0], task)
     assert platform['name'] == expected
-
-
-@pytest.mark.parametrize(
-    'create, expect',
-    (
-        (['suite.rc', 'log/conf/flow-processed.cylc'], True),
-        (['suite.rc', 'foo/bar/any-old.file'], True),
-        (['flow.cylc', 'log/conf/flow-processed.cylc'], False),
-        (['flow.cylc', 'where/flow-processed.cylc'], False),
-    )
-)
-def test_get_compat_mode(tmp_path, create, expect):
-    """It checks whether there is a suite.rc two directories up."""
-    for file in create:
-        file = tmp_path / file
-        file.parent.mkdir(parents=True, exist_ok=True)
-        file.touch()
-    assert get_compat_mode(tmp_path) == expect
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A set of changes to remove Cylc 7 compatibility mode, issues:

* https://github.com/cylc/cylc-flow/issues/6849 
* https://github.com/cylc/cylc-flow/issues/6850
* https://github.com/cylc/cylc-rose/issues/374

Sibling PRs:

* [x] [cylc-flow](https://github.com/cylc/cylc-flow/pull/7325)
* [x] [cylc-doc](https://github.com/cylc/cylc-doc/pull/939)

Summary:

* Remove Cylc 7 compat logic - addresses https://github.com/cylc/cylc-flow/issues/6849 
* Remove legacy support for Python 2 / Jinja2 v2 templating - closes https://github.com/cylc/cylc-rose/issues/374

**Check List**

- [x] I have read `CONTRIBUTING.md` and added my name as a Code Contributor.
- [x] Contains logically grouped changes (else tidy your branch by rebase).
- [x] Does not contain off-topic changes (use other PRs for other changes).
- [x] Applied any dependency changes to both `setup.cfg` (and `conda-environment.yml` if present).
- [x] Tests are included (or explain why tests are not needed).
- [x] Changelog entry included if this is a change that can affect users
- [x] [Cylc-Doc](https://github.com/cylc/cylc-doc) pull request opened if required at cylc/cylc-doc/pull/XXXX.
- [x] If this is a bug fix, PR should be raised against the relevant `?.?.x` branch.