### PR TITLE
actions: run main test CI on a schedule

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ on:
       - 'pyproject.toml'
       - 'README.md'       # check markdown is valid
       - 'MANIFEST.in'     # check packaging
+  schedule:
+    - cron: '53 0 * * 1-5' # 00:53 Mon-Fri
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Run our main CI actions one a week in order to detect new failures caused by external factors.

This will help us to keep the project status page fresher: https://cylc.github.io/cylc-admin/status/status.html

Examples of external factors:

    New lint rules.
    New mypy improvements.
    Changes in an upstream Cylc repository.
    Changes in the [meta-release configuration](https://cylc.github.io/cylc-admin/status/status.html#branches).
    New releases of dependent software (incl. Python).
    Changes in GH actions (e.g, new runners, or removed support for old ones).
    Etc.